### PR TITLE
APPROVED : Add webgl backend to tilemap_renderer

### DIFF
--- a/examples/minwebgl/hexagonal_map/src/main.rs
+++ b/examples/minwebgl/hexagonal_map/src/main.rs
@@ -189,6 +189,7 @@ async fn run() -> Result< (), gl::WebglError >
       id : res_id,
       source : assets::ImageSource::Path( PathBuf::from( &sprite.source ) ),
       filter : SamplerFilter::Linear,
+      mipmap : MipmapMode::Off,
     });
   }
 

--- a/examples/minwebgl/hexagonal_map/src/main.rs
+++ b/examples/minwebgl/hexagonal_map/src/main.rs
@@ -43,7 +43,7 @@ use browser_input::{ keyboard::KeyboardKey, mouse::MouseButton, Action, Event, E
 use gl::{ JsCast as _, I32x2, F32x2, Vector };
 use tilemap_renderer::
 {
-  adapters::WebGlBackend,
+  adapters::webgl::WebGlBackend,
   backend::Backend,
   types::*,
   commands,

--- a/module/helper/tilemap_renderer/Cargo.toml
+++ b/module/helper/tilemap_renderer/Cargo.toml
@@ -16,6 +16,7 @@ default = ["enabled"]
 full = ["enabled", "adapter-svg", "adapter-terminal", "adapter-webgl", "cli"]
 adapter-svg = ["enabled", "dep:base64"]
 adapter-terminal = ["enabled"]
+# Requires wasm32-unknown-unknown target.
 adapter-webgl = [
   "enabled",
   "dep:minwebgl",

--- a/module/helper/tilemap_renderer/Cargo.toml
+++ b/module/helper/tilemap_renderer/Cargo.toml
@@ -22,6 +22,7 @@ adapter-webgl = [
   "dep:web-sys",
   "dep:js-sys",
   "dep:wasm-bindgen",
+  "dep:bytemuck"
 ]
 # CLI stub — not yet reimplemented
 cli = ["enabled"]
@@ -35,5 +36,6 @@ wasm-bindgen = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 error_tools = { workspace = true, optional = true }
 mod_interface = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/module/helper/tilemap_renderer/readme.md
+++ b/module/helper/tilemap_renderer/readme.md
@@ -93,7 +93,15 @@ let Output::String( doc ) = svg.output()? else { unreachable!() };
 >
 > ¹ WebGL blend modes: Normal, Add, Multiply, Screen are hardware-accelerated.
 > `BlendMode::Overlay` (Photoshop-style) cannot be expressed as a single `blend_func` call
-> and currently falls back to Normal; a custom shader or FBO pass is required.
+> and currently falls back to Normal; a custom shader or FBO pass is required. Because
+> not all variants render correctly, `Capabilities::blend_modes` is `false` on this
+> backend; query `Capabilities::supported_blend_modes: &'static [BlendMode]` for the
+> precise set (`[Normal, Add, Multiply, Screen]`).
+>
+> **Depth (WebGL):** `Transform::depth` is honored via the depth buffer (`LEQUAL`, higher
+> values drawn on top, NDC range `[-1, 1]`). Correct only for fully opaque draws — submit
+> translucent content back-to-front as you would for a painter's-algorithm renderer. SVG
+> and terminal adapters still emit in submission order and ignore `depth`.
 
 ## license
 

--- a/module/helper/tilemap_renderer/readme.md
+++ b/module/helper/tilemap_renderer/readme.md
@@ -85,11 +85,15 @@ let Output::String( doc ) = svg.output()? else { unreachable!() };
 | Batches | yes | yes | — |
 | Gradients | yes | — | — |
 | Effects | yes | — | — |
-| Blend modes | yes | yes | — |
+| Blend modes | yes | partial¹ | — |
 
 > **SVG** and **Terminal** adapters are currently stub implementations (deferred to follow-up PRs).
 > **WebGL** adapter is partially implemented: sprites, meshes, and instanced batches work;
 > paths, text, groups, gradients, patterns, and effects are not yet rendered.
+>
+> ¹ WebGL blend modes: Normal, Add, Multiply, Screen are hardware-accelerated.
+> `BlendMode::Overlay` (Photoshop-style) cannot be expressed as a single `blend_func` call
+> and currently falls back to Normal; a custom shader or FBO pass is required.
 
 ## license
 

--- a/module/helper/tilemap_renderer/readme.md
+++ b/module/helper/tilemap_renderer/readme.md
@@ -35,11 +35,11 @@ tilemap_renderer/
 
 ## features
 
-| Feature | Description |
-|---------|-------------|
-| `adapter-svg` | SVG backend — generates SVG 1.1 documents |
-| `adapter-webgl` | WebGL2 backend — instanced rendering, GPU batches (wasm32) |
-| `adapter-terminal` | Terminal backend — ASCII art output |
+| Feature | Status | Description |
+|---------|--------|-------------|
+| `adapter-svg` | stub | SVG backend — generates SVG 1.1 documents |
+| `adapter-webgl` | partial | WebGL2 backend — sprites, meshes, instanced batches (wasm32); paths/text/effects pending |
+| `adapter-terminal` | stub | Terminal backend — ASCII art output |
 
 Default: no features enabled (core only, zero backend dependencies).
 
@@ -86,6 +86,10 @@ let Output::String( doc ) = svg.output()? else { unreachable!() };
 | Gradients | yes | — | — |
 | Effects | yes | — | — |
 | Blend modes | yes | yes | — |
+
+> **SVG** and **Terminal** adapters are currently stub implementations (deferred to follow-up PRs).
+> **WebGL** adapter is partially implemented: sprites, meshes, and instanced batches work;
+> paths, text, groups, gradients, patterns, and effects are not yet rendered.
 
 ## license
 

--- a/module/helper/tilemap_renderer/readme.md
+++ b/module/helper/tilemap_renderer/readme.md
@@ -30,6 +30,8 @@ tilemap_renderer/
 └── adapters/
     ├── svg.rs      # SVG 1.1 document generation
     ├── webgl.rs    # WebGL2 hardware-accelerated rendering (wasm32)
+    ├── webgl/
+    │   └── webgl_helpers.rs  # Self-contained WebGL types (ArrayBuffer, GPU handles, GL mappers)
     └── terminal.rs # ASCII/Unicode terminal output
 ```
 
@@ -99,9 +101,13 @@ let Output::String( doc ) = svg.output()? else { unreachable!() };
 > precise set (`[Normal, Add, Multiply, Screen]`).
 >
 > **Depth (WebGL):** `Transform::depth` is honored via the depth buffer (`LEQUAL`, higher
-> values drawn on top, NDC range `[-1, 1]`). Correct only for fully opaque draws — submit
-> translucent content back-to-front as you would for a painter's-algorithm renderer. SVG
-> and terminal adapters still emit in submission order and ignore `depth`.
+> values drawn on top). Valid range is `[-RenderConfig::max_depth, RenderConfig::max_depth]`
+> (default `1.0`, backwards-compatible); the shader divides by `max_depth` and lets the
+> GPU clip values outside the range. In batches the **sum** `parent_depth + instance_depth`
+> must stay within the range — out-of-range sums are clipped. Correct only for fully
+> opaque draws — submit translucent content back-to-front as you would for a
+> painter's-algorithm renderer. SVG and terminal adapters still emit in submission order
+> and ignore `depth` / `max_depth`.
 
 ## license
 

--- a/module/helper/tilemap_renderer/roadmap.md
+++ b/module/helper/tilemap_renderer/roadmap.md
@@ -6,7 +6,7 @@
 
 ## current state
 
-The core library is functional. The engine uses a flat command stream architecture with POD commands and a `Backend` trait. Backend adapters are stub implementations deferred to follow-up PRs.
+The core library is functional and the WebGL2 adapter is partially implemented. The engine uses a flat command stream architecture with POD commands and a `Backend` trait.
 
 ### completed
 
@@ -15,11 +15,19 @@ The core library is functional. The engine uses a flat command stream architectu
 - **Asset system** — images (bitmap/encoded/path), sprites, geometries, gradients, patterns, clip masks, paths, validation
 - **Backend trait** — `load_assets`, `submit`, `output`, `resize`, `capabilities`
 - **Test suite** — 39 tests covering types, commands, assets validation, and backend trait
+- **WebGL2 adapter (partial)** — hardware-accelerated sprites, meshes, and instanced batches on wasm32:
+  - `ArrayBuffer<T>` — GPU-side Vec with 2× grow via `copy_buffer_sub_data` (no CPU readback)
+  - `SpriteInstanceData` (68B) and `MeshInstanceData` (36B) with compile-time layout assertions
+  - Single-draw: `Clear`, `Mesh` (with texture + topology), `Sprite` (with tint)
+  - Batch lifecycle: `Create`, `Bind`, `Add/Set/Remove` instances, `Draw`, `Delete` — for both sprite and mesh batches
+  - Per-batch VAO setup at create/unbind time; bind-only at draw time
+  - Asset loading: images (Bitmap sync + Path async via `spawn_local`), sprites, geometries (sync + async path)
+  - All blend modes: Normal, Add, Multiply, Screen, Overlay
+  - Shaders: `sprite.vert/frag`, `sprite_batch.vert/frag`, `mesh.vert/frag`, `mesh_batch.vert`
 
 ### deferred to follow-up PRs
 
 - **SVG adapter** — stub only (`adapter-svg` feature gate exists; implementation pending)
-- **WebGL2 adapter** — stub only (`adapter-webgl` feature gate exists; implementation pending)
 - **Terminal adapter** — stub only (`adapter-terminal` feature gate exists; implementation pending)
 
 ### project structure
@@ -48,11 +56,14 @@ tilemap_renderer/           # Single crate with feature-gated adapters
 
 ### webgl adapter gaps
 
-- Path rendering (tessellation or GPU-based curves)
-- Text rendering (glyph atlas or SDF fonts)
-- Gradient/pattern fill support
+- Path rendering (tessellation or GPU-based curves) — path commands are currently silent no-ops
+- Text rendering (glyph atlas or SDF fonts) — text commands are currently silent no-ops
+- Group commands (`BeginGroup`/`EndGroup`) — currently ignored
+- `ImageSource::Encoded` decoding — skipped with TODO
+- Gradient/pattern/clip-mask asset loading — not loaded into GPU resources
 - Effects (blur, drop shadow — requires FBO post-processing)
-- WebGL context loss handling
+- WebGL context loss handling (`webglcontextlost` / `webglcontextrestored` events)
+- `capabilities()` reports `paths/text/gradients/patterns/clip_masks/effects: true` — should be corrected to `false` once the corresponding features are verified absent
 
 ### svg adapter gaps
 

--- a/module/helper/tilemap_renderer/roadmap.md
+++ b/module/helper/tilemap_renderer/roadmap.md
@@ -22,14 +22,14 @@ The core library is functional and the WebGL2 adapter is partially implemented. 
   - `ArrayBuffer<T>` — GPU-side Vec with 2× grow via `copy_buffer_sub_data` (no CPU readback);
     `swap_remove` uses a persistent scratch buffer to avoid binding the same buffer to both
     `COPY_READ_BUFFER` and `COPY_WRITE_BUFFER` (WebGL2 spec violation)
-  - `SpriteInstanceData` (72B) and `MeshInstanceData` (40B) with compile-time layout assertions
+  - `SpriteInstanceData` (72B, includes per-instance tint) and `MeshInstanceData` (56B, includes per-instance tint) with compile-time layout assertions
   - Single-draw: `Clear`, `Mesh` (with texture + topology), `Sprite` (with tint)
   - Batch lifecycle: `Create`, `Bind`, `Add/Set/Remove` instances, `Draw`, `Delete` — for both sprite and mesh batches
   - Per-batch VAO setup at create/unbind time; bind-only at draw time
   - Asset loading: images (Bitmap sync + Path async via `spawn_local`), sprites, geometries (sync + async path); async handlers use `Closure::once_into_js` so the browser drops the Rust closures (and captured `Rc<RefCell<GpuResources>>`) after `onload` / `onerror` fires, letting `WebGlBackend` drop actually free GPU resources
   - `Transform::depth` — honored via depth buffer (`DEPTH_TEST`, `LEQUAL`). Per-field range `[-RenderConfig::max_depth, max_depth]` (default `1.0`); shader divides by `u_max_depth`, GPU clips out-of-range values. Batch sum `parent_depth + instance_depth` is subject to the same range. Reliable for fully opaque draws (translucent must be back-to-front)
   - Blend modes: Normal, Add, Multiply, Screen (hardware-accelerated); Overlay falls back to Normal. `Capabilities::supported_blend_modes` advertises the correct set; `blend_modes: bool` means "all variants correct" and is `false` until Overlay is implemented
-  - Shaders: `sprite.vert/frag`, `sprite_batch.vert/frag`, `mesh.vert/frag`, `mesh_batch.vert`
+  - Shaders: `sprite.vert/frag`, `sprite_batch.vert/frag`, `mesh.vert/frag`, `mesh_batch.vert/frag`
 
 ### deferred to follow-up PRs
 

--- a/module/helper/tilemap_renderer/roadmap.md
+++ b/module/helper/tilemap_renderer/roadmap.md
@@ -10,19 +10,24 @@ The core library is functional and the WebGL2 adapter is partially implemented. 
 
 ### completed
 
-- **Core types** — `Transform`, `ResourceId<T>`, `RenderConfig`, blend modes, topology, coordinate system (Y-up)
+- **Core types** — `Transform`, `ResourceId<T>`, `RenderConfig` (incl. configurable `max_depth`), blend modes, topology, coordinate system (Y-up)
 - **Command system** — all POD commands: Clear, Path (moveto/lineto/quad/cubic/arc/close), Text, Mesh, Sprite, Batch lifecycle, Groups with effects
 - **Asset system** — images (bitmap/encoded/path), sprites, geometries, gradients, patterns, clip masks, paths, validation
 - **Backend trait** — `load_assets`, `submit`, `output`, `resize`, `capabilities`
 - **Test suite** — 39 tests covering types, commands, assets validation, and backend trait
 - **WebGL2 adapter (partial)** — hardware-accelerated sprites, meshes, and instanced batches on wasm32:
-  - `ArrayBuffer<T>` — GPU-side Vec with 2× grow via `copy_buffer_sub_data` (no CPU readback)
+  - Split across `adapters/webgl.rs` (backend + renderers + async image loader) and
+    `adapters/webgl/webgl_helpers.rs` (self-contained helpers wired via `mod_interface::layer`)
+    to stay under the per-file size budget
+  - `ArrayBuffer<T>` — GPU-side Vec with 2× grow via `copy_buffer_sub_data` (no CPU readback);
+    `swap_remove` uses a persistent scratch buffer to avoid binding the same buffer to both
+    `COPY_READ_BUFFER` and `COPY_WRITE_BUFFER` (WebGL2 spec violation)
   - `SpriteInstanceData` (72B) and `MeshInstanceData` (40B) with compile-time layout assertions
   - Single-draw: `Clear`, `Mesh` (with texture + topology), `Sprite` (with tint)
   - Batch lifecycle: `Create`, `Bind`, `Add/Set/Remove` instances, `Draw`, `Delete` — for both sprite and mesh batches
   - Per-batch VAO setup at create/unbind time; bind-only at draw time
-  - Asset loading: images (Bitmap sync + Path async via `spawn_local`), sprites, geometries (sync + async path)
-  - `Transform::depth` — honored via depth buffer (`DEPTH_TEST`, `LEQUAL`, NDC range `[-1, 1]`); reliable for fully opaque draws (translucent must be back-to-front)
+  - Asset loading: images (Bitmap sync + Path async via `spawn_local`), sprites, geometries (sync + async path); async handlers use `Closure::once_into_js` so the browser drops the Rust closures (and captured `Rc<RefCell<GpuResources>>`) after `onload` / `onerror` fires, letting `WebGlBackend` drop actually free GPU resources
+  - `Transform::depth` — honored via depth buffer (`DEPTH_TEST`, `LEQUAL`). Per-field range `[-RenderConfig::max_depth, max_depth]` (default `1.0`); shader divides by `u_max_depth`, GPU clips out-of-range values. Batch sum `parent_depth + instance_depth` is subject to the same range. Reliable for fully opaque draws (translucent must be back-to-front)
   - Blend modes: Normal, Add, Multiply, Screen (hardware-accelerated); Overlay falls back to Normal. `Capabilities::supported_blend_modes` advertises the correct set; `blend_modes: bool` means "all variants correct" and is `false` until Overlay is implemented
   - Shaders: `sprite.vert/frag`, `sprite_batch.vert/frag`, `mesh.vert/frag`, `mesh_batch.vert`
 
@@ -44,7 +49,9 @@ tilemap_renderer/           # Single crate with feature-gated adapters
 │   └── adapters/
 │       ├── mod.rs          # Feature-gated re-exports
 │       ├── svg.rs          # SVG 1.1 backend
-│       ├── webgl.rs        # WebGL2 backend (wasm32)
+│       ├── webgl.rs        # WebGL2 backend entry point (WebGlBackend + renderers)
+│       ├── webgl/          # WebGL submodule layer
+│       │   └── webgl_helpers.rs  # ArrayBuffer, GPU handles, GL mappers, batch types
 │       ├── terminal.rs     # Terminal backend
 │       └── shaders/        # GLSL shaders for WebGL
 ├── Cargo.toml

--- a/module/helper/tilemap_renderer/roadmap.md
+++ b/module/helper/tilemap_renderer/roadmap.md
@@ -17,12 +17,13 @@ The core library is functional and the WebGL2 adapter is partially implemented. 
 - **Test suite** — 39 tests covering types, commands, assets validation, and backend trait
 - **WebGL2 adapter (partial)** — hardware-accelerated sprites, meshes, and instanced batches on wasm32:
   - `ArrayBuffer<T>` — GPU-side Vec with 2× grow via `copy_buffer_sub_data` (no CPU readback)
-  - `SpriteInstanceData` (68B) and `MeshInstanceData` (36B) with compile-time layout assertions
+  - `SpriteInstanceData` (72B) and `MeshInstanceData` (40B) with compile-time layout assertions
   - Single-draw: `Clear`, `Mesh` (with texture + topology), `Sprite` (with tint)
   - Batch lifecycle: `Create`, `Bind`, `Add/Set/Remove` instances, `Draw`, `Delete` — for both sprite and mesh batches
   - Per-batch VAO setup at create/unbind time; bind-only at draw time
   - Asset loading: images (Bitmap sync + Path async via `spawn_local`), sprites, geometries (sync + async path)
-  - Blend modes: Normal, Add, Multiply, Screen (hardware-accelerated); Overlay falls back to Normal (see gaps)
+  - `Transform::depth` — honored via depth buffer (`DEPTH_TEST`, `LEQUAL`, NDC range `[-1, 1]`); reliable for fully opaque draws (translucent must be back-to-front)
+  - Blend modes: Normal, Add, Multiply, Screen (hardware-accelerated); Overlay falls back to Normal. `Capabilities::supported_blend_modes` advertises the correct set; `blend_modes: bool` means "all variants correct" and is `false` until Overlay is implemented
   - Shaders: `sprite.vert/frag`, `sprite_batch.vert/frag`, `mesh.vert/frag`, `mesh_batch.vert`
 
 ### deferred to follow-up PRs

--- a/module/helper/tilemap_renderer/roadmap.md
+++ b/module/helper/tilemap_renderer/roadmap.md
@@ -64,7 +64,6 @@ tilemap_renderer/           # Single crate with feature-gated adapters
 - Effects (blur, drop shadow — requires FBO post-processing)
 - `BlendMode::Overlay` — Photoshop-style (Multiply where dst<0.5, Screen where dst>0.5) cannot be expressed as a single `blend_func` call; currently falls back to Normal; requires a custom shader or separate FBO read-back pass
 - WebGL context loss handling (`webglcontextlost` / `webglcontextrestored` events)
-- `capabilities()` reports `paths/text/gradients/patterns/clip_masks/effects: true` — should be corrected to `false` once the corresponding features are verified absent
 
 ### svg adapter gaps
 

--- a/module/helper/tilemap_renderer/roadmap.md
+++ b/module/helper/tilemap_renderer/roadmap.md
@@ -22,7 +22,7 @@ The core library is functional and the WebGL2 adapter is partially implemented. 
   - Batch lifecycle: `Create`, `Bind`, `Add/Set/Remove` instances, `Draw`, `Delete` — for both sprite and mesh batches
   - Per-batch VAO setup at create/unbind time; bind-only at draw time
   - Asset loading: images (Bitmap sync + Path async via `spawn_local`), sprites, geometries (sync + async path)
-  - All blend modes: Normal, Add, Multiply, Screen, Overlay
+  - Blend modes: Normal, Add, Multiply, Screen (hardware-accelerated); Overlay falls back to Normal (see gaps)
   - Shaders: `sprite.vert/frag`, `sprite_batch.vert/frag`, `mesh.vert/frag`, `mesh_batch.vert`
 
 ### deferred to follow-up PRs
@@ -62,6 +62,7 @@ tilemap_renderer/           # Single crate with feature-gated adapters
 - `ImageSource::Encoded` decoding — skipped with TODO
 - Gradient/pattern/clip-mask asset loading — not loaded into GPU resources
 - Effects (blur, drop shadow — requires FBO post-processing)
+- `BlendMode::Overlay` — Photoshop-style (Multiply where dst<0.5, Screen where dst>0.5) cannot be expressed as a single `blend_func` call; currently falls back to Normal; requires a custom shader or separate FBO read-back pass
 - WebGL context loss handling (`webglcontextlost` / `webglcontextrestored` events)
 - `capabilities()` reports `paths/text/gradients/patterns/clip_masks/effects: true` — should be corrected to `false` once the corresponding features are verified absent
 

--- a/module/helper/tilemap_renderer/spec.md
+++ b/module/helper/tilemap_renderer/spec.md
@@ -150,8 +150,8 @@ pub trait Backend {
 - `ArrayBuffer<T>` — GPU-side Vec with dynamic grow (copy_buffer_sub_data); uses a persistent
   scratch buffer to avoid the WebGL2 spec violation of binding the same buffer to both
   `COPY_READ_BUFFER` and `COPY_WRITE_BUFFER` in `swap_remove`
-- Instanced rendering: `SpriteInstanceData` (72B), `MeshInstanceData` (40B) — each carries a
-  per-instance `depth` float (compile-time layout assertions enforce the sizes)
+- Instanced rendering: `SpriteInstanceData` (72B), `MeshInstanceData` (56B) — each carries
+  per-instance `depth` and `tint` (compile-time layout assertions enforce the sizes)
 - Depth buffer enabled (`DEPTH_TEST`, `LEQUAL`); `Transform::depth` honored for fully opaque
   draws. Range `[-RenderConfig::max_depth, max_depth]` per field (default `1.0`); the shader
   divides by `u_max_depth` so out-of-range depths are clipped by the GPU rather than silently
@@ -160,7 +160,7 @@ pub trait Backend {
 - Async image loading uses `Closure::once_into_js` for one-shot `onload` / `onerror` handlers,
   so the browser drops the Rust closures (and their captured `Rc<RefCell<GpuResources>>`)
   after the event — a `WebGlBackend` drop actually releases its GPU resources
-- Shaders: sprite.vert/frag, sprite_batch.vert, mesh.vert/frag, mesh_batch.vert
+- Shaders: sprite.vert/frag, sprite_batch.vert/frag, mesh.vert/frag, mesh_batch.vert/frag
 - Quad vertices generated in vertex shader via `gl_VertexID`
 
 #### 7.3. Terminal (`adapter-terminal`)
@@ -233,7 +233,7 @@ pub trait Backend {
 - **NFR-5:** ✅ 100% documentation coverage (zero warnings)
 - **NFR-6:** ✅ All command types are POD (Copy, Clone)
 - **NFR-7:** ✅ Test suite: 39 tests (types, commands, assets, backend trait); adapter tests deferred to adapter PRs
-- **NFR-8:** ✅ Compile-time layout assertions for GPU data structures (`SpriteInstanceData` 72B, `MeshInstanceData` 40B)
+- **NFR-8:** ✅ Compile-time layout assertions for GPU data structures (`SpriteInstanceData` 72B, `MeshInstanceData` 56B)
 - **NFR-9:** ❌ Visual regression testing
 - **NFR-10:** ❌ CI with feature matrix
 
@@ -263,7 +263,7 @@ pub trait Backend {
 | ✅ | NFR-4 | Y-up coordinate system |
 | ✅ | NFR-5 | 100% doc coverage |
 | ✅ | NFR-7 | Test suite |
-| ✅ | NFR-8 | Compile-time layout assertions for GPU structs |
+| ✅ | NFR-8 | Compile-time layout assertions for GPU structs (SpriteInstanceData 72B, MeshInstanceData 56B) |
 | ❌ | NFR-1 | Performance benchmarks |
 | ❌ | NFR-9 | Visual regression tests |
 | ❌ | NFR-10 | CI feature matrix |

--- a/module/helper/tilemap_renderer/spec.md
+++ b/module/helper/tilemap_renderer/spec.md
@@ -198,6 +198,7 @@ pub trait Backend {
 - **FR-E6:** ❌ Text rendering (glyph atlas / SDF fonts)
 - **FR-E7:** ❌ WebGL context loss handling
 - **FR-E8:** ❌ Effects (blur, shadow — requires FBO post-processing)
+- **FR-E9:** ⚠️ Blend modes — Normal/Add/Multiply/Screen hardware-accelerated; `Overlay` falls back to Normal (requires custom shader or FBO read-back)
 
 #### FR-F: Terminal Backend
 
@@ -238,6 +239,7 @@ pub trait Backend {
 | ⏳ | FR-D1–D9 | SVG backend — deferred to adapter-svg PR |
 | ⚠️ | FR-E1–E4 | WebGL backend partial (sprites, meshes, batches work; paths, text, effects missing) |
 | ❌ | FR-E5–E8 | WebGL: paths, text, context loss, effects — not implemented |
+| ⚠️ | FR-E9 | WebGL blend modes partial — Overlay falls back to Normal |
 | ⏳ | FR-F1–F3 | Terminal backend — deferred to adapter-terminal PR |
 | ✅ | NFR-2 | Zero core graphics deps |
 | ✅ | NFR-4 | Y-up coordinate system |

--- a/module/helper/tilemap_renderer/spec.md
+++ b/module/helper/tilemap_renderer/spec.md
@@ -190,14 +190,14 @@ pub trait Backend {
 
 #### FR-E: WebGL Backend
 
-- **FR-E1:** ⏳ Uses `minwebgl` crate (deferred to adapter-webgl PR)
-- **FR-E2:** ⏳ Hardware-accelerated WASM rendering (deferred to adapter-webgl PR)
-- **FR-E3:** ⏳ Instanced batching for sprites and meshes (deferred to adapter-webgl PR)
-- **FR-E4:** ⏳ Per-batch VAO management (deferred to adapter-webgl PR)
+- **FR-E1:** ✅ Uses `minwebgl` crate
+- **FR-E2:** ✅ Hardware-accelerated WASM rendering (sprites, meshes, batches)
+- **FR-E3:** ✅ Instanced batching for sprites and meshes
+- **FR-E4:** ✅ Per-batch VAO management (setup at create/unbind, bind-only at draw)
 - **FR-E5:** ❌ Path rendering (tessellation/GPU curves)
-- **FR-E6:** ❌ Text rendering
+- **FR-E6:** ❌ Text rendering (glyph atlas / SDF fonts)
 - **FR-E7:** ❌ WebGL context loss handling
-- **FR-E8:** ❌ Effects (blur, shadow — requires FBO)
+- **FR-E8:** ❌ Effects (blur, shadow — requires FBO post-processing)
 
 #### FR-F: Terminal Backend
 
@@ -215,7 +215,7 @@ pub trait Backend {
 - **NFR-5:** ✅ 100% documentation coverage (zero warnings)
 - **NFR-6:** ✅ All command types are POD (Copy, Clone)
 - **NFR-7:** ✅ Test suite: 39 tests (types, commands, assets, backend trait); adapter tests deferred to adapter PRs
-- **NFR-8:** ❌ Compile-time layout assertions for GPU data structures (deferred to WebGL/wgpu adapter PRs)
+- **NFR-8:** ✅ Compile-time layout assertions for GPU data structures (`SpriteInstanceData` 68B, `MeshInstanceData` 36B)
 - **NFR-9:** ❌ Visual regression testing
 - **NFR-10:** ❌ CI with feature matrix
 
@@ -236,12 +236,14 @@ pub trait Backend {
 | ✅ | FR-C2 | Capabilities |
 | ✅ | FR-C3 | RenderError |
 | ⏳ | FR-D1–D9 | SVG backend — deferred to adapter-svg PR |
-| ⏳ | FR-E1–E4 | WebGL backend — deferred to adapter-webgl PR |
+| ⚠️ | FR-E1–E4 | WebGL backend partial (sprites, meshes, batches work; paths, text, effects missing) |
+| ❌ | FR-E5–E8 | WebGL: paths, text, context loss, effects — not implemented |
 | ⏳ | FR-F1–F3 | Terminal backend — deferred to adapter-terminal PR |
 | ✅ | NFR-2 | Zero core graphics deps |
 | ✅ | NFR-4 | Y-up coordinate system |
 | ✅ | NFR-5 | 100% doc coverage |
 | ✅ | NFR-7 | Test suite |
+| ✅ | NFR-8 | Compile-time layout assertions for GPU structs |
 | ❌ | NFR-1 | Performance benchmarks |
 | ❌ | NFR-9 | Visual regression tests |
 | ❌ | NFR-10 | CI feature matrix |

--- a/module/helper/tilemap_renderer/spec.md
+++ b/module/helper/tilemap_renderer/spec.md
@@ -2,7 +2,7 @@
 
 - **Name:** Agnostic 2D Render Engine
 - **Version:** 0.2.0
-- **Date:** 2026-03-11
+- **Date:** 2026-04-22
 
 ### table of contents
 
@@ -79,7 +79,7 @@ All backends use **Y-up**:
 - `Transform` — position `[f32; 2]`, rotation `f32`, scale `[f32; 2]`, skew `[f32; 2]`, depth `f32`
 - `Transform::to_mat3()` — column-major 3×3 affine matrix
 - `ResourceId<T>` — phantom-typed u32 handle, nohash for IntMap/IntSet
-- `RenderConfig` — width, height, antialias, background
+- `RenderConfig` — width, height, antialias, background, max_depth
 - Enums: `BlendMode`, `LineCap`, `LineJoin`, `TextAnchor`, `Topology`, `SamplerFilter`, `Antialias`
 - `FillRef` — None, Solid, Gradient, Pattern
 - `DashStyle` — stroke dash pattern with offset
@@ -141,10 +141,25 @@ pub trait Backend {
 #### 7.2. WebGL2 (`adapter-webgl`)
 
 - Hardware-accelerated via `minwebgl` crate (wasm32 target)
-- `ArrayBuffer<T>` — GPU-side Vec with dynamic grow (copy_buffer_sub_data)
-- Instanced rendering: `SpriteInstanceData` (72B), `MeshInstanceData` (40B) — each carries a per-instance `depth` float
-- Depth buffer enabled (`DEPTH_TEST`, `LEQUAL`); `Transform::depth` honored for fully opaque draws
+- Split across two files to stay under the per-file size budget:
+  - `adapters/webgl.rs` — `WebGlBackend`, `SpriteRenderer`, `MeshRenderer`, async image loader
+  - `adapters/webgl/webgl_helpers.rs` (submodule via `mod_interface::layer`) — self-contained helpers:
+    `ArrayBuffer<T>`, `SpriteInstanceData` / `MeshInstanceData`, `GpuResources` / `GpuTexture` /
+    `GpuSprite` / `GpuGeometry` / `GpuBatch`, VAO setup, async `Loadable`, GL mapping helpers
+    (`index_format`, `apply_texture_filter`, `apply_blend`, `topology_to_gl`)
+- `ArrayBuffer<T>` — GPU-side Vec with dynamic grow (copy_buffer_sub_data); uses a persistent
+  scratch buffer to avoid the WebGL2 spec violation of binding the same buffer to both
+  `COPY_READ_BUFFER` and `COPY_WRITE_BUFFER` in `swap_remove`
+- Instanced rendering: `SpriteInstanceData` (72B), `MeshInstanceData` (40B) — each carries a
+  per-instance `depth` float (compile-time layout assertions enforce the sizes)
+- Depth buffer enabled (`DEPTH_TEST`, `LEQUAL`); `Transform::depth` honored for fully opaque
+  draws. Range `[-RenderConfig::max_depth, max_depth]` per field (default `1.0`); the shader
+  divides by `u_max_depth` so out-of-range depths are clipped by the GPU rather than silently
+  saturated
 - Per-batch VAO with attrib setup at create/unbind time, just bind at draw time
+- Async image loading uses `Closure::once_into_js` for one-shot `onload` / `onerror` handlers,
+  so the browser drops the Rust closures (and their captured `Rc<RefCell<GpuResources>>`)
+  after the event — a `WebGlBackend` drop actually releases its GPU resources
 - Shaders: sprite.vert/frag, sprite_batch.vert, mesh.vert/frag, mesh_batch.vert
 - Quad vertices generated in vertex shader via `gl_VertexID`
 
@@ -200,7 +215,7 @@ pub trait Backend {
 - **FR-E7:** ❌ WebGL context loss handling
 - **FR-E8:** ❌ Effects (blur, shadow — requires FBO post-processing)
 - **FR-E9:** ⚠️ Blend modes — Normal/Add/Multiply/Screen hardware-accelerated; `Overlay` falls back to Normal (requires custom shader or FBO read-back). `Capabilities::blend_modes` is `false` (not all variants correct); `Capabilities::supported_blend_modes` advertises the precise set
-- **FR-E10:** ⚠️ `Transform::depth` — honored via depth buffer (`DEPTH_TEST`, `LEQUAL`, higher = on top, NDC range `[-1, 1]`). Reliable only for fully opaque draws; translucent content must still be submitted back-to-front
+- **FR-E10:** ⚠️ `Transform::depth` — honored via depth buffer (`DEPTH_TEST`, `LEQUAL`, higher = on top). Per-field range is `[-RenderConfig::max_depth, max_depth]` (default `1.0`); the shader divides by `max_depth` and the GPU clips values outside the range. For batches the **sum** `parent_depth + instance_depth` must satisfy the same constraint. Reliable only for fully opaque draws; translucent content must still be submitted back-to-front
 
 #### FR-F: Terminal Backend
 
@@ -242,7 +257,7 @@ pub trait Backend {
 | ⚠️ | FR-E1–E4 | WebGL backend partial (sprites, meshes, batches work; paths, text, effects missing) |
 | ❌ | FR-E5–E8 | WebGL: paths, text, context loss, effects — not implemented |
 | ⚠️ | FR-E9 | WebGL blend modes partial — Overlay falls back to Normal; `supported_blend_modes` lists the correct set |
-| ⚠️ | FR-E10 | WebGL depth honored for opaque draws only (translucent must be back-to-front) |
+| ⚠️ | FR-E10 | WebGL depth honored for opaque draws only (range `[-max_depth, max_depth]`, out-of-range values clipped by the GPU; translucent must be back-to-front) |
 | ⏳ | FR-F1–F3 | Terminal backend — deferred to adapter-terminal PR |
 | ✅ | NFR-2 | Zero core graphics deps |
 | ✅ | NFR-4 | Y-up coordinate system |

--- a/module/helper/tilemap_renderer/spec.md
+++ b/module/helper/tilemap_renderer/spec.md
@@ -142,7 +142,8 @@ pub trait Backend {
 
 - Hardware-accelerated via `minwebgl` crate (wasm32 target)
 - `ArrayBuffer<T>` — GPU-side Vec with dynamic grow (copy_buffer_sub_data)
-- Instanced rendering: `SpriteInstanceData` (68B), `MeshInstanceData` (36B)
+- Instanced rendering: `SpriteInstanceData` (72B), `MeshInstanceData` (40B) — each carries a per-instance `depth` float
+- Depth buffer enabled (`DEPTH_TEST`, `LEQUAL`); `Transform::depth` honored for fully opaque draws
 - Per-batch VAO with attrib setup at create/unbind time, just bind at draw time
 - Shaders: sprite.vert/frag, sprite_batch.vert, mesh.vert/frag, mesh_batch.vert
 - Quad vertices generated in vertex shader via `gl_VertexID`
@@ -173,7 +174,7 @@ pub trait Backend {
 #### FR-C: Backend Interface
 
 - **FR-C1:** ✅ `Backend` trait with load_assets/submit/output/resize/capabilities
-- **FR-C2:** ✅ `Capabilities` struct for runtime feature discovery
+- **FR-C2:** ✅ `Capabilities` struct for runtime feature discovery (coarse `bool` flags plus `supported_blend_modes: &'static [BlendMode]` for per-variant queries)
 - **FR-C3:** ✅ `RenderError` for graceful error handling
 
 #### FR-D: SVG Backend
@@ -198,7 +199,8 @@ pub trait Backend {
 - **FR-E6:** ❌ Text rendering (glyph atlas / SDF fonts)
 - **FR-E7:** ❌ WebGL context loss handling
 - **FR-E8:** ❌ Effects (blur, shadow — requires FBO post-processing)
-- **FR-E9:** ⚠️ Blend modes — Normal/Add/Multiply/Screen hardware-accelerated; `Overlay` falls back to Normal (requires custom shader or FBO read-back)
+- **FR-E9:** ⚠️ Blend modes — Normal/Add/Multiply/Screen hardware-accelerated; `Overlay` falls back to Normal (requires custom shader or FBO read-back). `Capabilities::blend_modes` is `false` (not all variants correct); `Capabilities::supported_blend_modes` advertises the precise set
+- **FR-E10:** ⚠️ `Transform::depth` — honored via depth buffer (`DEPTH_TEST`, `LEQUAL`, higher = on top, NDC range `[-1, 1]`). Reliable only for fully opaque draws; translucent content must still be submitted back-to-front
 
 #### FR-F: Terminal Backend
 
@@ -216,7 +218,7 @@ pub trait Backend {
 - **NFR-5:** ✅ 100% documentation coverage (zero warnings)
 - **NFR-6:** ✅ All command types are POD (Copy, Clone)
 - **NFR-7:** ✅ Test suite: 39 tests (types, commands, assets, backend trait); adapter tests deferred to adapter PRs
-- **NFR-8:** ✅ Compile-time layout assertions for GPU data structures (`SpriteInstanceData` 68B, `MeshInstanceData` 36B)
+- **NFR-8:** ✅ Compile-time layout assertions for GPU data structures (`SpriteInstanceData` 72B, `MeshInstanceData` 40B)
 - **NFR-9:** ❌ Visual regression testing
 - **NFR-10:** ❌ CI with feature matrix
 
@@ -239,7 +241,8 @@ pub trait Backend {
 | ⏳ | FR-D1–D9 | SVG backend — deferred to adapter-svg PR |
 | ⚠️ | FR-E1–E4 | WebGL backend partial (sprites, meshes, batches work; paths, text, effects missing) |
 | ❌ | FR-E5–E8 | WebGL: paths, text, context loss, effects — not implemented |
-| ⚠️ | FR-E9 | WebGL blend modes partial — Overlay falls back to Normal |
+| ⚠️ | FR-E9 | WebGL blend modes partial — Overlay falls back to Normal; `supported_blend_modes` lists the correct set |
+| ⚠️ | FR-E10 | WebGL depth honored for opaque draws only (translucent must be back-to-front) |
 | ⏳ | FR-F1–F3 | Terminal backend — deferred to adapter-terminal PR |
 | ✅ | NFR-2 | Zero core graphics deps |
 | ✅ | NFR-4 | Y-up coordinate system |

--- a/module/helper/tilemap_renderer/src/adapters/mod.rs
+++ b/module/helper/tilemap_renderer/src/adapters/mod.rs
@@ -10,6 +10,6 @@ mod_interface::mod_interface!
   #[ cfg( feature = "adapter-terminal" ) ]
   layer terminal;
 
-  #[ cfg( all( feature = "adapter-webgl", target_arch = "wasm32" ) ) ]
+  #[ cfg( all( feature = "adapter-webgl" ) ) ]
   layer webgl;
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh.frag
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh.frag
@@ -1,0 +1,23 @@
+#version 300 es
+precision highp float;
+
+in vec2 v_uv;
+
+uniform vec4 u_color;         // solid fill color
+uniform sampler2D u_texture;  // optional texture
+uniform bool u_use_texture;   // whether to sample texture
+
+out vec4 frag_color;
+
+void main()
+{
+  if ( u_use_texture )
+  {
+    vec4 tex = texture( u_texture, v_uv );
+    frag_color = tex * u_color;
+  }
+  else
+  {
+    frag_color = u_color;
+  }
+}

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh.vert
@@ -6,6 +6,7 @@ layout( location = 1 ) in vec2 a_uv; // optional, zero if no UVs
 
 uniform mat3 u_transform;
 uniform vec2 u_viewport;
+uniform float u_depth;       // NDC z; higher Transform::depth → drawn on top
 
 out vec2 v_uv;
 
@@ -17,5 +18,6 @@ void main()
 
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
-  gl_Position = vec4( ndc, 0.0, 1.0 );
+  // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
+  gl_Position = vec4( ndc, -u_depth, 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh.vert
@@ -6,7 +6,8 @@ layout( location = 1 ) in vec2 a_uv; // optional, zero if no UVs
 
 uniform mat3 u_transform;
 uniform vec2 u_viewport;
-uniform float u_depth;       // NDC z; higher Transform::depth → drawn on top
+uniform float u_depth;       // Transform::depth; range [-u_max_depth, u_max_depth]
+uniform float u_max_depth;   // RenderConfig::max_depth; defines the usable depth range
 
 out vec2 v_uv;
 
@@ -19,5 +20,7 @@ void main()
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
   // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
-  gl_Position = vec4( ndc, -u_depth, 1.0 );
+  // Divide by u_max_depth to map [-max_depth, max_depth] → [-1, 1], and clamp
+  // defensively so out-of-contract values saturate rather than being clipped.
+  gl_Position = vec4( ndc, clamp( -u_depth / u_max_depth, -1.0, 1.0 ), 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh.vert
@@ -1,0 +1,21 @@
+#version 300 es
+precision highp float;
+
+layout( location = 0 ) in vec2 a_position;
+layout( location = 1 ) in vec2 a_uv; // optional, zero if no UVs
+
+uniform mat3 u_transform;
+uniform vec2 u_viewport;
+
+out vec2 v_uv;
+
+void main()
+{
+  v_uv = a_uv;
+
+  vec3 world = u_transform * vec3( a_position, 1.0 );
+
+  vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
+
+  gl_Position = vec4( ndc, 0.0, 1.0 );
+}

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh.vert
@@ -20,7 +20,9 @@ void main()
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
   // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
-  // Divide by u_max_depth to map [-max_depth, max_depth] → [-1, 1], and clamp
-  // defensively so out-of-contract values saturate rather than being clipped.
-  gl_Position = vec4( ndc, clamp( -u_depth / u_max_depth, -1.0, 1.0 ), 1.0 );
+  // Divide by u_max_depth to map [-max_depth, max_depth] → [-1, 1].
+  // Out-of-contract depths fall outside [-1, 1] and are clipped by the GPU —
+  // that visible failure is preferable to a clamp that would silently collapse
+  // ordering among overflow values.
+  gl_Position = vec4( ndc, -u_depth / u_max_depth, 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.frag
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.frag
@@ -13,9 +13,8 @@ out vec4 frag_color;
 void main()
 {
   // Per-instance tint (v_tint) modulates the batch-level fill and any sampled
-  // texture. With tint = (1, 1, 1, 1) the output matches the single-draw mesh
-  // path, so existing calls stay visually identical after the tint field is
-  // added.
+  // texture. Passing tint = (1, 1, 1, 1) yields the same output as the
+  // single-draw path (mesh.frag), which has no per-instance tint.
   if ( u_use_texture )
   {
     vec4 tex = texture( u_texture, v_uv );

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.frag
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.frag
@@ -1,0 +1,28 @@
+#version 300 es
+precision highp float;
+
+in vec2 v_uv;
+in vec4 v_tint;
+
+uniform vec4 u_color;         // MeshBatchParams.fill — batch-level solid color
+uniform sampler2D u_texture;  // optional texture
+uniform bool u_use_texture;   // whether to sample texture
+
+out vec4 frag_color;
+
+void main()
+{
+  // Per-instance tint (v_tint) modulates the batch-level fill and any sampled
+  // texture. With tint = (1, 1, 1, 1) the output matches the single-draw mesh
+  // path, so existing calls stay visually identical after the tint field is
+  // added.
+  if ( u_use_texture )
+  {
+    vec4 tex = texture( u_texture, v_uv );
+    frag_color = tex * u_color * v_tint;
+  }
+  else
+  {
+    frag_color = u_color * v_tint;
+  }
+}

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
@@ -14,6 +14,7 @@ layout( location = 5 ) in float i_depth;
 uniform vec2 u_viewport;
 uniform mat3 u_parent; // batch parent transform
 uniform float u_parent_depth;
+uniform float u_max_depth; // RenderConfig::max_depth; defines the usable depth range
 
 out vec2 v_uv;
 
@@ -28,5 +29,12 @@ void main()
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
   // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
-  gl_Position = vec4( ndc, -( u_parent_depth + i_depth ), 1.0 );
+  // Each of `u_parent_depth` / `i_depth` is individually in
+  // [-u_max_depth, u_max_depth] by contract, but their sum can reach
+  // [-2*u_max_depth, 2*u_max_depth]; divide by u_max_depth and clamp to the
+  // clip-space z range so out-of-contract sums saturate rather than being
+  // silently clipped. Callers should still keep the sum in
+  // [-u_max_depth, u_max_depth] for correct ordering (see Transform::depth
+  // and MeshBatchParams docs).
+  gl_Position = vec4( ndc, clamp( -( u_parent_depth + i_depth ) / u_max_depth, -1.0, 1.0 ), 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
@@ -1,0 +1,28 @@
+#version 300 es
+precision highp float;
+
+// Per-vertex (from geometry VAO)
+layout( location = 0 ) in vec2 a_position;
+layout( location = 1 ) in vec2 a_uv;
+
+// Per-instance (divisor = 1)
+layout( location = 2 ) in vec3 i_transform_0;
+layout( location = 3 ) in vec3 i_transform_1;
+layout( location = 4 ) in vec3 i_transform_2;
+
+uniform vec2 u_viewport;
+uniform mat3 u_parent; // batch parent transform
+
+out vec2 v_uv;
+
+void main()
+{
+  v_uv = a_uv;
+
+  mat3 inst = transpose( mat3( i_transform_0, i_transform_1, i_transform_2 ) );
+  vec3 world = u_parent * inst * vec3( a_position, 1.0 );
+
+  vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
+
+  gl_Position = vec4( ndc, 0.0, 1.0 );
+}

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
@@ -19,7 +19,8 @@ void main()
 {
   v_uv = a_uv;
 
-  mat3 inst = transpose( mat3( i_transform_0, i_transform_1, i_transform_2 ) );
+  // Instance transform: each i_transform_N is a column of the column-major matrix from Transform::to_mat3().
+  mat3 inst = mat3( i_transform_0, i_transform_1, i_transform_2 );
   vec3 world = u_parent * inst * vec3( a_position, 1.0 );
 
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
@@ -30,11 +30,10 @@ void main()
 
   // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
   // Each of `u_parent_depth` / `i_depth` is individually in
-  // [-u_max_depth, u_max_depth] by contract, but their sum can reach
-  // [-2*u_max_depth, 2*u_max_depth]; divide by u_max_depth and clamp to the
-  // clip-space z range so out-of-contract sums saturate rather than being
-  // silently clipped. Callers should still keep the sum in
-  // [-u_max_depth, u_max_depth] for correct ordering (see Transform::depth
-  // and MeshBatchParams docs).
-  gl_Position = vec4( ndc, clamp( -( u_parent_depth + i_depth ) / u_max_depth, -1.0, 1.0 ), 1.0 );
+  // [-u_max_depth, u_max_depth] by contract; their sum is the caller's
+  // responsibility to keep within the same range. Divide by u_max_depth so the
+  // in-contract sum maps into clip-space [-1, 1]. Out-of-contract sums are
+  // clipped by the GPU — the caller will see geometry disappear, which is
+  // easier to diagnose than the silent z-fighting a clamp would introduce.
+  gl_Position = vec4( ndc, -( u_parent_depth + i_depth ) / u_max_depth, 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
@@ -10,6 +10,7 @@ layout( location = 2 ) in vec3 i_transform_0;
 layout( location = 3 ) in vec3 i_transform_1;
 layout( location = 4 ) in vec3 i_transform_2;
 layout( location = 5 ) in float i_depth;
+layout( location = 6 ) in vec4 i_tint;
 
 uniform vec2 u_viewport;
 uniform mat3 u_parent; // batch parent transform
@@ -17,10 +18,12 @@ uniform float u_parent_depth;
 uniform float u_max_depth; // RenderConfig::max_depth; defines the usable depth range
 
 out vec2 v_uv;
+out vec4 v_tint;
 
 void main()
 {
   v_uv = a_uv;
+  v_tint = i_tint;
 
   // Instance transform: each i_transform_N is a column of the column-major matrix from Transform::to_mat3().
   mat3 inst = mat3( i_transform_0, i_transform_1, i_transform_2 );

--- a/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/mesh_batch.vert
@@ -9,9 +9,11 @@ layout( location = 1 ) in vec2 a_uv;
 layout( location = 2 ) in vec3 i_transform_0;
 layout( location = 3 ) in vec3 i_transform_1;
 layout( location = 4 ) in vec3 i_transform_2;
+layout( location = 5 ) in float i_depth;
 
 uniform vec2 u_viewport;
 uniform mat3 u_parent; // batch parent transform
+uniform float u_parent_depth;
 
 out vec2 v_uv;
 
@@ -25,5 +27,6 @@ void main()
 
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
-  gl_Position = vec4( ndc, 0.0, 1.0 );
+  // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
+  gl_Position = vec4( ndc, -( u_parent_depth + i_depth ), 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite.frag
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite.frag
@@ -1,0 +1,15 @@
+#version 300 es
+precision highp float;
+
+in vec2 v_uv;
+
+uniform sampler2D u_texture;
+uniform vec4 u_tint; // multiply with texture color
+
+out vec4 frag_color;
+
+void main()
+{
+  vec4 tex = texture( u_texture, v_uv );
+  frag_color = tex * u_tint;
+}

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
@@ -1,0 +1,28 @@
+#version 300 es
+precision highp float;
+
+// Per-vertex
+layout( location = 0 ) in vec2 a_position; // unit quad 0..1
+layout( location = 1 ) in vec2 a_uv;
+
+// Uniforms
+uniform mat3 u_transform;   // model transform (column-major 3x3)
+uniform vec2 u_viewport;    // viewport size in pixels
+uniform vec4 u_uv_rect;     // sprite region: x, y, w, h in UV space
+uniform vec2 u_sprite_size;  // natural size of sprite region in pixels
+
+out vec2 v_uv;
+
+void main()
+{
+  // Map UV from full quad to sprite sub-region
+  v_uv = u_uv_rect.xy + a_uv * u_uv_rect.zw;
+
+  // Scale unit quad to sprite's natural pixel size, then apply transform
+  vec3 world = u_transform * vec3( a_position * u_sprite_size, 1.0 );
+
+  // Convert to clip space: pixel coords → -1..1 (Y-up)
+  vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
+
+  gl_Position = vec4( ndc, 0.0, 1.0 );
+}

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
@@ -1,25 +1,24 @@
 #version 300 es
 precision highp float;
 
-// Per-vertex
-layout( location = 0 ) in vec2 a_position; // unit quad 0..1
-layout( location = 1 ) in vec2 a_uv;
-
 // Uniforms
-uniform mat3 u_transform;   // model transform (column-major 3x3)
-uniform vec2 u_viewport;    // viewport size in pixels
-uniform vec4 u_uv_rect;     // sprite region: x, y, w, h in UV space
+uniform mat3 u_transform;    // model transform (column-major 3x3)
+uniform vec2 u_viewport;     // viewport size in pixels
+uniform vec4 u_uv_rect;      // sprite region: x, y, w, h in UV space (0..1)
 uniform vec2 u_sprite_size;  // natural size of sprite region in pixels
 
 out vec2 v_uv;
 
 void main()
 {
-  // Map UV from full quad to sprite sub-region
-  v_uv = u_uv_rect.xy + a_uv * u_uv_rect.zw;
+  // Generate unit quad from gl_VertexID (triangle strip: 0,1,2,3)
+  vec2 quad = vec2( float( gl_VertexID & 1 ), float( ( gl_VertexID >> 1 ) & 1 ) );
+
+  // Map quad corner to sprite sub-region UV
+  v_uv = u_uv_rect.xy + quad * u_uv_rect.zw;
 
   // Scale unit quad to sprite's natural pixel size, then apply transform
-  vec3 world = u_transform * vec3( a_position * u_sprite_size, 1.0 );
+  vec3 world = u_transform * vec3( quad * u_sprite_size, 1.0 );
 
   // Convert to clip space: pixel coords → -1..1 (Y-up)
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
@@ -26,7 +26,9 @@ void main()
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
   // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
-  // Divide by u_max_depth to map [-max_depth, max_depth] → [-1, 1], and clamp
-  // defensively so out-of-contract values saturate rather than being clipped.
-  gl_Position = vec4( ndc, clamp( -u_depth / u_max_depth, -1.0, 1.0 ), 1.0 );
+  // Divide by u_max_depth to map [-max_depth, max_depth] → [-1, 1].
+  // Out-of-contract depths fall outside [-1, 1] and are clipped by the GPU —
+  // that visible failure is preferable to a clamp that would silently collapse
+  // ordering among overflow values.
+  gl_Position = vec4( ndc, -u_depth / u_max_depth, 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
@@ -6,7 +6,8 @@ uniform mat3 u_transform;    // model transform (column-major 3x3)
 uniform vec2 u_viewport;     // viewport size in pixels
 uniform vec4 u_uv_rect;      // sprite region: x, y, w, h in UV space (0..1)
 uniform vec2 u_sprite_size;  // natural size of sprite region in pixels
-uniform float u_depth;       // NDC z; higher Transform::depth → drawn on top (see webgl.rs depth notes)
+uniform float u_depth;       // Transform::depth; range [-u_max_depth, u_max_depth]
+uniform float u_max_depth;   // RenderConfig::max_depth; defines the usable depth range
 
 out vec2 v_uv;
 
@@ -25,5 +26,7 @@ void main()
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
   // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
-  gl_Position = vec4( ndc, -u_depth, 1.0 );
+  // Divide by u_max_depth to map [-max_depth, max_depth] → [-1, 1], and clamp
+  // defensively so out-of-contract values saturate rather than being clipped.
+  gl_Position = vec4( ndc, clamp( -u_depth / u_max_depth, -1.0, 1.0 ), 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
@@ -6,6 +6,7 @@ uniform mat3 u_transform;    // model transform (column-major 3x3)
 uniform vec2 u_viewport;     // viewport size in pixels
 uniform vec4 u_uv_rect;      // sprite region: x, y, w, h in UV space (0..1)
 uniform vec2 u_sprite_size;  // natural size of sprite region in pixels
+uniform float u_depth;       // NDC z; higher Transform::depth → drawn on top (see webgl.rs depth notes)
 
 out vec2 v_uv;
 
@@ -23,5 +24,6 @@ void main()
   // Convert to clip space: pixel coords → -1..1 (Y-up)
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
-  gl_Position = vec4( ndc, 0.0, 1.0 );
+  // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
+  gl_Position = vec4( ndc, -u_depth, 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
@@ -16,7 +16,13 @@ void main()
   // Generate unit quad from gl_VertexID (triangle strip: 0,1,2,3)
   vec2 quad = vec2( float( gl_VertexID & 1 ), float( ( gl_VertexID >> 1 ) & 1 ) );
 
-  // Map quad corner to sprite sub-region UV
+  // Map quad corner to sprite sub-region UV.
+  // `u_uv_rect` is already in normalized UV space `[0..1]` — the Rust upload
+  // path divides the pixel region by the sheet's dimensions before calling
+  // `uniform_upload`. Contrast with `sprite_batch.vert`, which receives the
+  // region in pixels per-instance and divides by `u_tex_size` in the shader
+  // so per-instance data stays independent of the (possibly async-loaded)
+  // sheet's dimensions.
   v_uv = u_uv_rect.xy + quad * u_uv_rect.zw;
 
   // Scale unit quad to sprite's natural pixel size, then apply transform

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite.vert
@@ -4,8 +4,8 @@ precision highp float;
 // Uniforms
 uniform mat3 u_transform;    // model transform (column-major 3x3)
 uniform vec2 u_viewport;     // viewport size in pixels
-uniform vec4 u_uv_rect;      // sprite region: x, y, w, h in UV space (0..1)
-uniform vec2 u_sprite_size;  // natural size of sprite region in pixels
+uniform vec4 u_region;       // sprite region: x, y, w, h in pixels (same convention as sprite_batch.vert)
+uniform vec2 u_tex_size;     // sheet dimensions in pixels
 uniform float u_depth;       // Transform::depth; range [-u_max_depth, u_max_depth]
 uniform float u_max_depth;   // RenderConfig::max_depth; defines the usable depth range
 
@@ -16,17 +16,11 @@ void main()
   // Generate unit quad from gl_VertexID (triangle strip: 0,1,2,3)
   vec2 quad = vec2( float( gl_VertexID & 1 ), float( ( gl_VertexID >> 1 ) & 1 ) );
 
-  // Map quad corner to sprite sub-region UV.
-  // `u_uv_rect` is already in normalized UV space `[0..1]` — the Rust upload
-  // path divides the pixel region by the sheet's dimensions before calling
-  // `uniform_upload`. Contrast with `sprite_batch.vert`, which receives the
-  // region in pixels per-instance and divides by `u_tex_size` in the shader
-  // so per-instance data stays independent of the (possibly async-loaded)
-  // sheet's dimensions.
-  v_uv = u_uv_rect.xy + quad * u_uv_rect.zw;
+  // Compute UV from pixel region and sheet size (matches sprite_batch.vert).
+  v_uv = ( u_region.xy + quad * u_region.zw ) / u_tex_size;
 
-  // Scale unit quad to sprite's natural pixel size, then apply transform
-  vec3 world = u_transform * vec3( quad * u_sprite_size, 1.0 );
+  // Scale unit quad to sprite's pixel size (region.zw), then apply transform.
+  vec3 world = u_transform * vec3( quad * u_region.zw, 1.0 );
 
   // Convert to clip space: pixel coords → -1..1 (Y-up)
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.frag
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.frag
@@ -1,0 +1,14 @@
+#version 300 es
+precision highp float;
+
+in vec2 v_uv;
+in vec4 v_tint;
+
+uniform sampler2D u_texture;
+
+out vec4 frag_color;
+
+void main()
+{
+  frag_color = texture( u_texture, v_uv ) * v_tint;
+}

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
@@ -37,11 +37,10 @@ void main()
 
   // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
   // Each of `u_parent_depth` / `i_depth` is individually in
-  // [-u_max_depth, u_max_depth] by contract, but their sum can reach
-  // [-2*u_max_depth, 2*u_max_depth]; divide by u_max_depth and clamp to the
-  // clip-space z range so out-of-contract sums saturate rather than being
-  // silently clipped. Callers should still keep the sum in
-  // [-u_max_depth, u_max_depth] for correct ordering (see Transform::depth
-  // and SpriteBatchParams docs).
-  gl_Position = vec4( ndc, clamp( -( u_parent_depth + i_depth ) / u_max_depth, -1.0, 1.0 ), 1.0 );
+  // [-u_max_depth, u_max_depth] by contract; their sum is the caller's
+  // responsibility to keep within the same range. Divide by u_max_depth so the
+  // in-contract sum maps into clip-space [-1, 1]. Out-of-contract sums are
+  // clipped by the GPU — the caller will see geometry disappear, which is
+  // easier to diagnose than the silent z-fighting a clamp would introduce.
+  gl_Position = vec4( ndc, -( u_parent_depth + i_depth ) / u_max_depth, 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
@@ -24,8 +24,8 @@ void main()
   v_uv = ( i_region.xy + quad * i_region.zw ) / u_tex_size;
   v_tint = i_tint;
 
-  // Instance transform (row-major in buffer, transpose to column-major)
-  mat3 inst = transpose( mat3( i_transform_0, i_transform_1, i_transform_2 ) );
+  // Instance transform: each i_transform_N is a column of the column-major matrix from Transform::to_mat3().
+  mat3 inst = mat3( i_transform_0, i_transform_1, i_transform_2 );
 
   // Scale quad to sprite pixel size, apply instance then parent transform
   vec3 world = u_parent * inst * vec3( quad * i_region.zw, 1.0 );

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
@@ -1,0 +1,36 @@
+#version 300 es
+precision highp float;
+
+// Per-instance (divisor = 1)
+layout( location = 0 ) in vec3 i_transform_0;
+layout( location = 1 ) in vec3 i_transform_1;
+layout( location = 2 ) in vec3 i_transform_2;
+layout( location = 3 ) in vec4 i_region; // x, y, w, h in pixels
+layout( location = 4 ) in vec4 i_tint;
+
+uniform vec2 u_viewport;
+uniform vec2 u_tex_size; // sheet dimensions in pixels
+uniform mat3 u_parent;   // batch parent transform
+
+out vec2 v_uv;
+out vec4 v_tint;
+
+void main()
+{
+  // Generate unit quad from gl_VertexID (triangle strip: 0,1,2,3)
+  vec2 quad = vec2( float( gl_VertexID & 1 ), float( ( gl_VertexID >> 1 ) & 1 ) );
+
+  // Compute UV from pixel region and sheet size
+  v_uv = ( i_region.xy + quad * i_region.zw ) / u_tex_size;
+  v_tint = i_tint;
+
+  // Instance transform (row-major in buffer, transpose to column-major)
+  mat3 inst = transpose( mat3( i_transform_0, i_transform_1, i_transform_2 ) );
+
+  // Scale quad to sprite pixel size, apply instance then parent transform
+  vec3 world = u_parent * inst * vec3( quad * i_region.zw, 1.0 );
+
+  vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
+
+  gl_Position = vec4( ndc, 0.0, 1.0 );
+}

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
@@ -13,6 +13,7 @@ uniform vec2 u_viewport;
 uniform vec2 u_tex_size; // sheet dimensions in pixels
 uniform mat3 u_parent;   // batch parent transform
 uniform float u_parent_depth;
+uniform float u_max_depth; // RenderConfig::max_depth; defines the usable depth range
 
 out vec2 v_uv;
 out vec4 v_tint;
@@ -35,5 +36,12 @@ void main()
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
   // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
-  gl_Position = vec4( ndc, -( u_parent_depth + i_depth ), 1.0 );
+  // Each of `u_parent_depth` / `i_depth` is individually in
+  // [-u_max_depth, u_max_depth] by contract, but their sum can reach
+  // [-2*u_max_depth, 2*u_max_depth]; divide by u_max_depth and clamp to the
+  // clip-space z range so out-of-contract sums saturate rather than being
+  // silently clipped. Callers should still keep the sum in
+  // [-u_max_depth, u_max_depth] for correct ordering (see Transform::depth
+  // and SpriteBatchParams docs).
+  gl_Position = vec4( ndc, clamp( -( u_parent_depth + i_depth ) / u_max_depth, -1.0, 1.0 ), 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
@@ -7,10 +7,12 @@ layout( location = 1 ) in vec3 i_transform_1;
 layout( location = 2 ) in vec3 i_transform_2;
 layout( location = 3 ) in vec4 i_region; // x, y, w, h in pixels
 layout( location = 4 ) in vec4 i_tint;
+layout( location = 5 ) in float i_depth;
 
 uniform vec2 u_viewport;
 uniform vec2 u_tex_size; // sheet dimensions in pixels
 uniform mat3 u_parent;   // batch parent transform
+uniform float u_parent_depth;
 
 out vec2 v_uv;
 out vec4 v_tint;
@@ -32,5 +34,6 @@ void main()
 
   vec2 ndc = ( world.xy / u_viewport ) * 2.0 - 1.0;
 
-  gl_Position = vec4( ndc, 0.0, 1.0 );
+  // Negate so higher user depth → smaller clip-space z → wins LEQUAL depth test.
+  gl_Position = vec4( ndc, -( u_parent_depth + i_depth ), 1.0 );
 }

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
@@ -23,7 +23,13 @@ void main()
   // Generate unit quad from gl_VertexID (triangle strip: 0,1,2,3)
   vec2 quad = vec2( float( gl_VertexID & 1 ), float( ( gl_VertexID >> 1 ) & 1 ) );
 
-  // Compute UV from pixel region and sheet size
+  // Compute UV from pixel region and sheet size.
+  // `i_region` carries the sprite rect in pixels; normalization happens here
+  // rather than in Rust so per-instance data stays independent of the sheet's
+  // dimensions — a sheet loaded asynchronously can resolve its dimensions
+  // after instances have already been uploaded without requiring the
+  // instance buffer to be rewritten. Contrast with `sprite.vert`, which
+  // receives an already-normalized `[0..1]` rect from the Rust upload path.
   v_uv = ( i_region.xy + quad * i_region.zw ) / u_tex_size;
   v_tint = i_tint;
 

--- a/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
+++ b/module/helper/tilemap_renderer/src/adapters/shaders/sprite_batch.vert
@@ -25,11 +25,9 @@ void main()
 
   // Compute UV from pixel region and sheet size.
   // `i_region` carries the sprite rect in pixels; normalization happens here
-  // rather than in Rust so per-instance data stays independent of the sheet's
-  // dimensions — a sheet loaded asynchronously can resolve its dimensions
-  // after instances have already been uploaded without requiring the
-  // instance buffer to be rewritten. Contrast with `sprite.vert`, which
-  // receives an already-normalized `[0..1]` rect from the Rust upload path.
+  // rather than in Rust so per-instance data stays independent of the
+  // (possibly async-loaded) sheet's dimensions. `sprite.vert` uses the same
+  // convention for a consistent single-draw / batch UV pipeline.
   v_uv = ( i_region.xy + quad * i_region.zw ) / u_tex_size;
   v_tint = i_tint;
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -796,7 +796,7 @@ mod private
         // DST_COLOR factor multiplies dst by raw src.rgb (not src.rgb*src_a), so
         // partially transparent sources darken the destination more than the
         // reference formula prescribes. Exact only when src_alpha = 1.
-        // TODO(FBO): replace with Photoshop-accurate formula — see BlendMode::Multiply doc.
+        // qqq(FBO): replace with Photoshop-accurate formula — see BlendMode::Multiply doc.
         // Color: src*dst + dst*(1-src_a). Alpha: standard over.
         BlendMode::Multiply => gl.blend_func_separate( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
         // Same class of approximation as Multiply: the ONE / ONE_MINUS_SRC_COLOR
@@ -805,7 +805,7 @@ mod private
         // or when the source is premultiplied.
         // Color: src + dst*(1-src). Alpha: standard over.
         BlendMode::Screen => gl.blend_func_separate( gl::ONE, gl::ONE_MINUS_SRC_COLOR, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
-        // TODO: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
+        // qqq: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
         // expressed as a single blend_func call — it requires a custom shader or a
         // separate FBO read-back pass, neither of which is implemented yet.
         // Overlay falls back to Normal so rendering is at least visible; the
@@ -1330,7 +1330,7 @@ mod private
 
             ( tex, *width, *height )
           }
-          crate::assets::ImageSource::Encoded( _ ) => { continue; } // TODO: decode
+          crate::assets::ImageSource::Encoded( _ ) => { continue; } // qqq: decode
           crate::assets::ImageSource::Path( path ) =>
           {
             let path = path.as_path().to_str()
@@ -1604,7 +1604,7 @@ mod private
       self.load_images( &assets.images )?;
       self.load_sprites( &assets.sprites );
       self.load_geometries( &assets.geometries )?;
-      // TODO: gradients, patterns, clip masks, fonts
+      // qqq: gradients, patterns, clip masks, fonts
       Ok( () )
     }
 
@@ -1640,7 +1640,7 @@ mod private
           RenderCommand::DrawBatch( db ) => self.cmd_draw_batch( db, &viewport )?,
           RenderCommand::DeleteBatch( db ) => self.cmd_delete_batch( db ),
 
-          // Path — skip (TODO). Warn on the opener only (not MoveTo/LineTo/etc.)
+          // Path — skip (qqq). Warn on the opener only (not MoveTo/LineTo/etc.)
           // so a 1000-segment path produces one message, not 1000. `capabilities()`
           // already advertises `paths: false`; this is a DX nudge for callers who
           // submitted anyway.
@@ -1656,7 +1656,7 @@ mod private
           | RenderCommand::ClosePath( _ )
           | RenderCommand::EndPath( _ ) => {}
 
-          // Text — skip (TODO). See note above re: opener-only warning.
+          // Text — skip (qqq). See note above re: opener-only warning.
           RenderCommand::BeginText( _ ) => web_sys::console::warn_1
           (
             &"WebGlBackend: text commands are not implemented; BeginText..EndText will be ignored (see capabilities().text)".into()
@@ -1664,7 +1664,7 @@ mod private
           RenderCommand::Char( _ )
           | RenderCommand::EndText( _ ) => {}
 
-          // Grouping — skip (TODO).
+          // Grouping — skip (qqq).
           RenderCommand::BeginGroup( _ ) => web_sys::console::warn_1
           (
             &"WebGlBackend: group commands are not implemented; BeginGroup..EndGroup will be ignored (see capabilities().effects)".into()
@@ -1692,15 +1692,15 @@ mod private
     {
       Capabilities
       {
-        paths : false,       // TODO: tessellation / GPU curves
-        text : false,        // TODO: glyph atlas / SDF fonts
+        paths : false,       // qqq: tessellation / GPU curves
+        text : false,        // qqq: glyph atlas / SDF fonts
         meshes : true,
         sprites : true,
         batches : true,
-        gradients : false,   // TODO: not yet loaded or rendered
-        patterns : false,    // TODO: not yet loaded or rendered
-        clip_masks : false,  // TODO: not yet loaded or rendered
-        effects : false,     // TODO: requires FBO post-processing
+        gradients : false,   // qqq: not yet loaded or rendered
+        patterns : false,    // qqq: not yet loaded or rendered
+        clip_masks : false,  // qqq: not yet loaded or rendered
+        effects : false,     // qqq: requires FBO post-processing
         // `blend_modes` means "all variants correct"; Overlay silently falls back
         // to Normal in `apply_blend` (needs FBO / custom shader), so this is false.
         // Callers needing per-mode info should check `supported_blend_modes`.

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1772,9 +1772,24 @@ mod private
     // onload/onerror handlers. Dropping the Closure here would invalidate the JS
     // function pointer and cause a use-after-free when the browser fires the event.
     // forget() intentionally leaks the closure so it remains alive for the callback.
-    // This is a known one-time-per-image leak (two closures × ~3 captures each).
-    // TODO: replace with Closure::once once the image loading is refactored, which
-    //       would allow the browser to drop the closure automatically after one call.
+    //
+    // Leak accounting: two closures leak per path-based image per `load_assets`
+    // call (on_load + on_error). Only one of them ever fires, and neither is ever
+    // freed — both persist for the lifetime of the WebGL context. The on_load
+    // closure additionally captures `Rc<RefCell<GpuResources>>`, so its leak
+    // keeps `GpuResources` alive even after the owning `WebGlBackend` is dropped;
+    // every GPU texture / VAO / buffer inside then survives until page close.
+    // on_error only captures a `String` path, so it leaks memory but does not
+    // extend `GpuResources` lifetime.
+    //
+    // For long-lived single-backend apps the drift is small (~KB per image per
+    // reload); for test harnesses or multi-instance hosts that create and drop
+    // `WebGlBackend` it becomes a real resource leak.
+    //
+    // qqq : replace forget() with Closure::once / once_into_js so the browser
+    //       frees each closure after its single invocation. Blocked on refactor
+    //       of the load_assets flow — the current shape expects stable Fn-style
+    //       handlers across retries, which Closure::once cannot provide.
     on_load.forget();
     on_error.forget();
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1205,15 +1205,15 @@ mod private
     {
       Capabilities
       {
-        paths : true,
-        text : true,
+        paths : false,       // TODO: tessellation / GPU curves
+        text : false,        // TODO: glyph atlas / SDF fonts
         meshes : true,
         sprites : true,
         batches : true,
-        gradients : true,
-        patterns : true,
-        clip_masks : true,
-        effects : true,
+        gradients : false,   // TODO: not yet loaded or rendered
+        patterns : false,    // TODO: not yet loaded or rendered
+        clip_masks : false,  // TODO: not yet loaded or rendered
+        effects : false,     // TODO: requires FBO post-processing
         blend_modes : true,
         text_on_path : false,
         max_texture_size : 8192,

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -655,6 +655,7 @@ mod private
     resources : Rc< RefCell< GpuResources > >,
     sprite : SpriteRenderer,
     mesh : MeshRenderer,
+    max_texture_size : u32,
 
     // -- batch editing state --
     recording_batch : Option< ResourceId< Batch > >,
@@ -678,10 +679,15 @@ mod private
       gl.enable( gl::BLEND );
       gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA );
 
-      if !matches!( config.antialias, Antialias::None )
-      {
-        gl.enable( gl::SAMPLE_COVERAGE );
-      }
+      // Query the actual hardware limit; fall back to the WebGL2 guaranteed minimum.
+      // get_parameter returns a JsValue; as_f64() is the idiomatic way to extract it.
+      // u32::try_from(i64) rejects negatives; the i64 intermediate avoids cast_sign_loss.
+      let max_texture_size : u32 = gl
+        .get_parameter( gl::MAX_TEXTURE_SIZE )
+        .ok()
+        .and_then( | v | v.as_f64() )
+        .and_then( | v | u32::try_from( v as i64 ).ok() )
+        .unwrap_or( 2048 );
 
       Ok( Self
       {
@@ -690,6 +696,7 @@ mod private
         resources : Rc::new( RefCell::new( GpuResources::new() ) ),
         sprite,
         mesh,
+        max_texture_size,
         recording_batch : None,
       })
     }
@@ -1356,7 +1363,7 @@ mod private
         effects : false,     // TODO: requires FBO post-processing
         blend_modes : true,  // Normal/Add/Multiply/Screen work; Overlay falls back to Normal (needs custom shader)
         text_on_path : false,
-        max_texture_size : 8192,
+        max_texture_size : self.max_texture_size,
       }
     }
   }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1471,6 +1471,13 @@ mod private
     img.set_onload( Some( on_load.as_ref().unchecked_ref() ) );
     img.set_onerror( Some( on_error.as_ref().unchecked_ref() ) );
     img.set_src( src );
+    // SAFETY: the browser holds a reference to each closure via the img element's
+    // onload/onerror handlers. Dropping the Closure here would invalidate the JS
+    // function pointer and cause a use-after-free when the browser fires the event.
+    // forget() intentionally leaks the closure so it remains alive for the callback.
+    // This is a known one-time-per-image leak (two closures × ~3 captures each).
+    // TODO: replace with Closure::once once the image loading is refactored, which
+    //       would allow the browser to drop the closure automatically after one call.
     on_load.forget();
     on_error.forget();
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -8,491 +8,32 @@ mod private
 {
   use std::rc::Rc;
   use core::cell::{ Cell, RefCell };
-  use core::marker::PhantomData;
   use web_sys::HtmlImageElement;
   use wasm_bindgen::prelude::*;
   use minwebgl as gl;
-  use nohash_hasher::IntMap;
+  use super::webgl_helpers::
+  {
+    ArrayBuffer,
+    SpriteInstanceData,
+    MeshInstanceData,
+    GpuResources,
+    GpuTexture,
+    GpuSprite,
+    GpuGeometry,
+    GpuBatch,
+    setup_sprite_batch_vao,
+    setup_mesh_batch_vao,
+    apply_blend,
+    source_to_loadable,
+    resolve_loadable,
+    index_format,
+    apply_texture_filter,
+    topology_to_gl,
+  };
   use crate::assets::Assets;
   use crate::backend::*;
   use crate::commands::*;
   use crate::types::*;
-
-  // ============================================================================
-  // ArrayBuffer — GPU-side Vec<T>
-  // ============================================================================
-
-  /// GPU array buffer with `Vec`-like semantics.
-  ///
-  /// Stores elements of type `T` in a WebGL `ARRAY_BUFFER`.
-  /// Tracks length and capacity; grows by 2× when full using
-  /// `copy_buffer_sub_data` (GPU-to-GPU copy into a freshly allocated buffer).
-  /// `swap_remove` uses a persistent one-element scratch buffer as an intermediary
-  /// to avoid the WebGL2 spec violation of binding the same buffer to both
-  /// `COPY_READ_BUFFER` and `COPY_WRITE_BUFFER` simultaneously.
-  pub struct ArrayBuffer< T >
-  {
-    gl : gl::GL,
-    buffer : web_sys::WebGlBuffer,
-    /// One-element scratch buffer used by `swap_remove` as a GPU-side intermediary.
-    scratch : web_sys::WebGlBuffer,
-    len : u32,
-    capacity : u32,
-    _marker : PhantomData< T >,
-  }
-
-  impl< T : gl::AsBytes > ArrayBuffer< T >
-  {
-    /// Creates a new GPU array buffer with the given initial capacity (in elements).
-    ///
-    /// Allocates two GPU buffers: the main data buffer (`capacity * stride` bytes)
-    /// and a one-element scratch buffer (`stride` bytes) used by `swap_remove`.
-    ///
-    /// # Errors
-    /// Returns `WebglError` if any GPU buffer cannot be created, or if
-    /// `capacity * stride` overflows `i32` (WebGL buffer size limit).
-    pub fn new( gl : &gl::GL, capacity : u32 ) -> Result< Self, gl::WebglError >
-    {
-      let buffer = gl::buffer::create( gl )?;
-      let byte_size = capacity
-        .checked_mul( Self::stride() )
-        .and_then( | n | i32::try_from( n ).ok() )
-        .ok_or( gl::WebglError::FailedToAllocateResource( "Buffer" ) )?;
-      gl.bind_buffer( gl::ARRAY_BUFFER, Some( &buffer ) );
-      gl.buffer_data_with_i32( gl::ARRAY_BUFFER, byte_size, gl::DYNAMIC_DRAW );
-      gl.bind_buffer( gl::ARRAY_BUFFER, None );
-
-      let scratch = gl::buffer::create( gl )?;
-      gl.bind_buffer( gl::ARRAY_BUFFER, Some( &scratch ) );
-      gl.buffer_data_with_i32( gl::ARRAY_BUFFER, Self::stride() as i32, gl::DYNAMIC_DRAW );
-      gl.bind_buffer( gl::ARRAY_BUFFER, None );
-
-      Ok( Self { gl : gl.clone(), buffer, scratch, len : 0, capacity, _marker : PhantomData } )
-    }
-
-    /// Byte size of one element.
-    fn stride() -> u32
-    {
-      core::mem::size_of::< T >() as u32
-    }
-
-    /// Number of elements currently stored.
-    #[ must_use ]
-    pub fn len( &self ) -> u32 { self.len }
-
-    /// Whether the buffer is empty.
-    #[ must_use ]
-    pub fn is_empty( &self ) -> bool { self.len == 0 }
-
-    /// Returns a reference to the underlying `WebGlBuffer`.
-    #[ must_use ]
-    pub fn buffer( &self ) -> &web_sys::WebGlBuffer { &self.buffer }
-
-    /// Appends an element at the end, growing if necessary.
-    ///
-    /// # Errors
-    /// Returns `WebglError` if the GPU buffer needs to grow and allocation fails.
-    pub fn push( &mut self, value : &T ) -> Result< (), gl::WebglError >
-    {
-      if self.len >= self.capacity
-      {
-        self.grow()?;
-      }
-      let offset = self.len * Self::stride();
-      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &self.buffer ) );
-      self.gl.buffer_sub_data_with_i32_and_u8_array( gl::ARRAY_BUFFER, offset as i32, value.as_bytes() );
-      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
-      self.len += 1;
-      Ok( () )
-    }
-
-    /// Updates the element at `index` in-place.
-    ///
-    /// # Panics
-    /// Panics if `index >= len`.
-    pub fn set( &self, index : u32, value : &T )
-    {
-      assert!( index < self.len, "ArrayBuffer::set index out of bounds" );
-      let offset = index * Self::stride();
-      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &self.buffer ) );
-      self.gl.buffer_sub_data_with_i32_and_u8_array( gl::ARRAY_BUFFER, offset as i32, value.as_bytes() );
-      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
-    }
-
-    /// Removes the element at `index` by swapping with the last element.
-    /// Returns the new length.
-    ///
-    /// # Panics
-    /// Panics if `index >= len`.
-    pub fn swap_remove( &mut self, index : u32 ) -> u32
-    {
-      assert!( index < self.len, "ArrayBuffer::swap_remove index out of bounds" );
-      self.len -= 1;
-      if index < self.len
-      {
-        let stride = Self::stride() as i32;
-        let src_offset = self.len as i32 * stride;
-        let dst_offset = index as i32 * stride;
-
-        // Binding the same buffer to both COPY_READ_BUFFER and COPY_WRITE_BUFFER is a
-        // WebGL2 spec violation (INVALID_OPERATION). Use a persistent one-element scratch
-        // buffer as an intermediary: last → scratch → removed slot. Both copies use
-        // distinct buffer objects, so the spec is satisfied and the copies are GPU-only.
-        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.buffer ) );
-        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &self.scratch ) );
-        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
-        (
-          gl::COPY_READ_BUFFER,
-          gl::COPY_WRITE_BUFFER,
-          src_offset,
-          0,
-          stride,
-        );
-        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.scratch ) );
-        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &self.buffer ) );
-        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
-        (
-          gl::COPY_READ_BUFFER,
-          gl::COPY_WRITE_BUFFER,
-          0,
-          dst_offset,
-          stride,
-        );
-        self.gl.bind_buffer( gl::COPY_READ_BUFFER, None );
-        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, None );
-      }
-      self.len
-    }
-
-    /// Doubles the capacity, copying old data GPU-to-GPU.
-    fn grow( &mut self ) -> Result< (), gl::WebglError >
-    {
-      // saturating_mul avoids wrapping; the byte_size check below catches any overflow.
-      let new_capacity = self.capacity.saturating_mul( 2 ).max( 4 );
-      let new_byte_size = new_capacity
-        .checked_mul( Self::stride() )
-        .and_then( | n | i32::try_from( n ).ok() )
-        .ok_or( gl::WebglError::FailedToAllocateResource( "Buffer" ) )?;
-
-      let new_buffer = gl::buffer::create( &self.gl )?;
-      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &new_buffer ) );
-      self.gl.buffer_data_with_i32( gl::ARRAY_BUFFER, new_byte_size, gl::DYNAMIC_DRAW );
-      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
-
-      if self.len > 0
-      {
-        let copy_bytes = self.len * Self::stride();
-        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.buffer ) );
-        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &new_buffer ) );
-        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
-        (
-          gl::COPY_READ_BUFFER,
-          gl::COPY_WRITE_BUFFER,
-          0,
-          0,
-          copy_bytes as i32,
-        );
-        self.gl.bind_buffer( gl::COPY_READ_BUFFER, None );
-        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, None );
-      }
-
-      self.gl.delete_buffer( Some( &self.buffer ) );
-      self.buffer = new_buffer;
-      self.capacity = new_capacity;
-      Ok( () )
-    }
-  }
-
-  impl< T > Drop for ArrayBuffer< T >
-  {
-    fn drop( &mut self )
-    {
-      self.gl.delete_buffer( Some( &self.buffer ) );
-      self.gl.delete_buffer( Some( &self.scratch ) );
-    }
-  }
-
-  // ============================================================================
-  // GPU resource handles
-  // ============================================================================
-
-  /// Manages GPU-side resources: textures and geometry buffers.
-  struct GpuResources
-  {
-    textures : IntMap< ResourceId< asset::Image >, GpuTexture >,
-    sprites : IntMap< ResourceId< asset::Sprite >, GpuSprite >,
-    geometries : IntMap< ResourceId< asset::Geometry >, GpuGeometry >,
-    batches : IntMap< ResourceId< Batch >, GpuBatch >,
-    /// Incremented on every `load_assets` call. In-flight `spawn_local` futures
-    /// from a previous cycle capture the old value and bail out on resolve,
-    /// so stale async data cannot overwrite freshly-loaded entries.
-    generation : u32,
-  }
-
-  impl GpuResources
-  {
-    fn new() -> Self
-    {
-      Self
-      {
-        textures : IntMap::default(),
-        sprites : IntMap::default(),
-        geometries : IntMap::default(),
-        batches : IntMap::default(),
-        generation : 0,
-      }
-    }
-
-    fn texture( &self, id : ResourceId< asset::Image > ) -> Option< &GpuTexture >
-    {
-      self.textures.get( &id )
-    }
-
-    fn sprite( &self, id : ResourceId< asset::Sprite > ) -> Option< &GpuSprite >
-    {
-      self.sprites.get( &id )
-    }
-
-    fn geometry( &self, id : ResourceId< asset::Geometry > ) -> Option< &GpuGeometry >
-    {
-      self.geometries.get( &id )
-    }
-
-    fn batch( &self, id : ResourceId< Batch > ) -> Option< &GpuBatch >
-    {
-      self.batches.get( &id )
-    }
-
-    fn batch_mut( &mut self, id : ResourceId< Batch > ) -> Option< &mut GpuBatch >
-    {
-      self.batches.get_mut( &id )
-    }
-
-    fn store_texture( &mut self, id : ResourceId< asset::Image >, tex : GpuTexture )
-    {
-      self.textures.insert( id, tex );
-    }
-
-    fn store_sprite( &mut self, id : ResourceId< asset::Sprite >, sprite : GpuSprite )
-    {
-      self.sprites.insert( id, sprite );
-    }
-
-    fn store_geometry( &mut self, id : ResourceId< asset::Geometry >, geom : GpuGeometry )
-    {
-      self.geometries.insert( id, geom );
-    }
-
-    fn store_batch( &mut self, id : ResourceId< Batch >, batch : GpuBatch )
-    {
-      self.batches.insert( id, batch );
-    }
-  }
-
-  struct GpuTexture
-  {
-    gl : gl::GL,
-    texture : web_sys::WebGlTexture,
-    width : Cell< u32 >,
-    height : Cell< u32 >,
-    _filter : SamplerFilter,
-    _mipmap : MipmapMode,
-  }
-
-  impl Drop for GpuTexture
-  {
-    fn drop( &mut self )
-    {
-      self.gl.delete_texture( Some( &self.texture ) );
-    }
-  }
-
-  /// Sprite lookup data: sheet reference + pixel region.
-  /// UV rect and size are computed at draw time from the sheet's dimensions.
-  struct GpuSprite
-  {
-    /// Sheet texture to bind.
-    sheet : ResourceId< asset::Image >,
-    /// Region within the sheet: `[x, y, w, h]` in pixels.
-    region : [ f32; 4 ],
-  }
-
-  struct GpuGeometry
-  {
-    gl : gl::GL,
-    vao : web_sys::WebGlVertexArrayObject,
-    position_buffer : Option< web_sys::WebGlBuffer >,
-    uv_buffer : Option< web_sys::WebGlBuffer >,
-    index_buffer : Option< web_sys::WebGlBuffer >,
-    vertex_count : u32,
-    /// Number of indices and the GL type constant (`UNSIGNED_BYTE` / `UNSIGNED_SHORT` / `UNSIGNED_INT`).
-    /// `None` if the geometry has no index buffer (draw with `drawArrays`).
-    index_count : Option< ( u32, u32 ) >,
-  }
-
-  impl Drop for GpuGeometry
-  {
-    fn drop( &mut self )
-    {
-      self.gl.delete_vertex_array( Some( &self.vao ) );
-      if let Some( ref buf ) = self.position_buffer { self.gl.delete_buffer( Some( buf ) ); }
-      if let Some( ref buf ) = self.uv_buffer { self.gl.delete_buffer( Some( buf ) ); }
-      if let Some( ref buf ) = self.index_buffer { self.gl.delete_buffer( Some( buf ) ); }
-    }
-  }
-
-  // ---- Instance data for batches ----
-
-  /// Per-instance data for sprite batches (18 floats = 72 bytes).
-  #[ repr( C ) ]
-  #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
-  struct SpriteInstanceData
-  {
-    transform : [ f32; 9 ],
-    region : [ f32; 4 ],
-    tint : [ f32; 4 ],
-    depth : f32,
-  }
-
-  impl gl::AsBytes for SpriteInstanceData
-  {
-    fn as_bytes( &self ) -> &[ u8 ] { bytemuck::bytes_of( self ) }
-    fn len( &self ) -> usize { 1 }
-  }
-
-  /// Per-instance data for mesh batches (10 floats = 40 bytes).
-  #[ repr( C ) ]
-  #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
-  struct MeshInstanceData
-  {
-    transform : [ f32; 9 ],
-    depth : f32,
-  }
-
-  impl gl::AsBytes for MeshInstanceData
-  {
-    fn as_bytes( &self ) -> &[ u8 ] { bytemuck::bytes_of( self ) }
-    fn len( &self ) -> usize { 1 }
-  }
-
-  // Compile-time layout assertions — GPU attrib setup depends on these exact sizes.
-  const _ : () = assert!( core::mem::size_of::< SpriteInstanceData >() == 72 ); // 18 floats × 4
-  const _ : () = assert!( core::mem::size_of::< MeshInstanceData >() == 40 ); // 10 floats × 4
-  const _ : () = assert!( core::mem::align_of::< SpriteInstanceData >() == 4 ); // f32 alignment
-  const _ : () = assert!( core::mem::align_of::< MeshInstanceData >() == 4 );
-
-  /// Persistent batch — sprite or mesh.
-  enum GpuBatch
-  {
-    Sprite
-    {
-      gl : gl::GL,
-      instances : ArrayBuffer< SpriteInstanceData >,
-      vao : web_sys::WebGlVertexArrayObject,
-      params : SpriteBatchParams,
-    },
-    Mesh
-    {
-      gl : gl::GL,
-      instances : ArrayBuffer< MeshInstanceData >,
-      vao : web_sys::WebGlVertexArrayObject,
-      params : MeshBatchParams,
-    },
-  }
-
-  impl Drop for GpuBatch
-  {
-    fn drop( &mut self )
-    {
-      match self
-      {
-        Self::Sprite { gl, vao, .. } | Self::Mesh { gl, vao, .. } =>
-          gl.delete_vertex_array( Some( vao ) ),
-      }
-    }
-  }
-
-  /// Binds instance attrib pointers for a sprite batch VAO.
-  fn setup_sprite_batch_vao( gl : &gl::GL, vao : &web_sys::WebGlVertexArrayObject, buffer : &web_sys::WebGlBuffer )
-  {
-    gl.bind_vertex_array( Some( vao ) );
-    gl.bind_buffer( gl::ARRAY_BUFFER, Some( buffer ) );
-
-    let stride = core::mem::size_of::< SpriteInstanceData >() as i32;
-
-    // transform: 3 × vec3 at locations 0, 1, 2
-    for i in 0..3_u32
-    {
-      gl.enable_vertex_attrib_array( i );
-      gl.vertex_attrib_pointer_with_i32( i, 3, gl::FLOAT, false, stride, ( i * 12 ) as i32 );
-      gl.vertex_attrib_divisor( i, 1 );
-    }
-    // region: vec4 at location 3, offset 36
-    gl.enable_vertex_attrib_array( 3 );
-    gl.vertex_attrib_pointer_with_i32( 3, 4, gl::FLOAT, false, stride, 36 );
-    gl.vertex_attrib_divisor( 3, 1 );
-    // tint: vec4 at location 4, offset 52
-    gl.enable_vertex_attrib_array( 4 );
-    gl.vertex_attrib_pointer_with_i32( 4, 4, gl::FLOAT, false, stride, 52 );
-    gl.vertex_attrib_divisor( 4, 1 );
-    // depth: float at location 5, offset 68
-    gl.enable_vertex_attrib_array( 5 );
-    gl.vertex_attrib_pointer_with_i32( 5, 1, gl::FLOAT, false, stride, 68 );
-    gl.vertex_attrib_divisor( 5, 1 );
-
-    gl.bind_vertex_array( None );
-  }
-
-  /// Sets up a mesh batch VAO with geometry attribs (0–1) and instance attribs (2–5).
-  fn setup_mesh_batch_vao
-  (
-    gl : &gl::GL,
-    vao : &web_sys::WebGlVertexArrayObject,
-    geom : &GpuGeometry,
-    instance_buffer : &web_sys::WebGlBuffer,
-  )
-  {
-    gl.bind_vertex_array( Some( vao ) );
-
-    // Geometry: positions (attrib 0)
-    if let Some( ref buf ) = geom.position_buffer
-    {
-      gl.bind_buffer( gl::ARRAY_BUFFER, Some( buf ) );
-      gl.enable_vertex_attrib_array( 0 );
-      gl.vertex_attrib_pointer_with_i32( 0, 2, gl::FLOAT, false, 0, 0 );
-    }
-
-    // Geometry: UVs (attrib 1)
-    if let Some( ref buf ) = geom.uv_buffer
-    {
-      gl.bind_buffer( gl::ARRAY_BUFFER, Some( buf ) );
-      gl.enable_vertex_attrib_array( 1 );
-      gl.vertex_attrib_pointer_with_i32( 1, 2, gl::FLOAT, false, 0, 0 );
-    }
-
-    // Geometry: indices
-    if let Some( ref buf ) = geom.index_buffer
-    {
-      gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( buf ) );
-    }
-
-    // Instance: transform 3 × vec3 at locations 2, 3, 4
-    gl.bind_buffer( gl::ARRAY_BUFFER, Some( instance_buffer ) );
-    let stride = core::mem::size_of::< MeshInstanceData >() as i32;
-    for i in 0..3_u32
-    {
-      let loc = i + 2;
-      gl.enable_vertex_attrib_array( loc );
-      gl.vertex_attrib_pointer_with_i32( loc, 3, gl::FLOAT, false, stride, ( i * 12 ) as i32 );
-      gl.vertex_attrib_divisor( loc, 1 );
-    }
-    // depth: float at location 5, offset 36
-    gl.enable_vertex_attrib_array( 5 );
-    gl.vertex_attrib_pointer_with_i32( 5, 1, gl::FLOAT, false, stride, 36 );
-    gl.vertex_attrib_divisor( 5, 1 );
-
-    gl.bind_vertex_array( None );
-  }
 
   // ============================================================================
   // Sprite renderer
@@ -778,51 +319,6 @@ mod private
       [ self.config.width as f32, self.config.height as f32 ]
     }
 
-    // ---- Blend ----
-
-    fn apply_blend( &self, blend : &BlendMode )
-    {
-      let gl = &self.gl;
-      // Alpha factors are always (ONE, ONE_MINUS_SRC_ALPHA) so the framebuffer alpha
-      // follows Porter-Duff "over": a = src_a + dst_a * (1 - src_a). Using the RGB
-      // factors on the alpha channel would produce wrong framebuffer alpha (e.g.
-      // src_a^2 under Normal) and break readPixels / compositing onto a transparent
-      // canvas background.
-      match blend
-      {
-        // Color: src + dst. Alpha: standard over.
-        BlendMode::Add => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
-        // Approximation: diverges from Photoshop Multiply when src_alpha < 1 — the
-        // DST_COLOR factor multiplies dst by raw src.rgb (not src.rgb*src_a), so
-        // partially transparent sources darken the destination more than the
-        // reference formula prescribes. Exact only when src_alpha = 1.
-        // qqq(FBO): replace with Photoshop-accurate formula — see BlendMode::Multiply doc.
-        // Color: src*dst + dst*(1-src_a). Alpha: standard over.
-        BlendMode::Multiply => gl.blend_func_separate( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
-        // Same class of approximation as Multiply: the ONE / ONE_MINUS_SRC_COLOR
-        // factors use raw src.rgb, so a partially transparent source still
-        // contributes its full (unmultiplied) color. Exact only when src_alpha = 1
-        // or when the source is premultiplied.
-        // Color: src + dst*(1-src). Alpha: standard over.
-        BlendMode::Screen => gl.blend_func_separate( gl::ONE, gl::ONE_MINUS_SRC_COLOR, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
-        // qqq: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
-        // expressed as a single blend_func call — it requires a custom shader or a
-        // separate FBO read-back pass, neither of which is implemented yet.
-        // Overlay falls back to Normal so rendering is at least visible; the
-        // console.warn below makes the silent substitution observable.
-        BlendMode::Overlay =>
-        {
-          web_sys::console::warn_1
-          (
-            &"BlendMode::Overlay is not supported in WebGL2 without an FBO pass; falling back to Normal".into()
-          );
-          gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA );
-        }
-        // Color: src*src_a + dst*(1-src_a). Alpha: standard over.
-        BlendMode::Normal => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
-      }
-    }
-
     // ---- Command handlers ----
     //
     // Contract for batch-targeting commands (cmd_add_*_instance, cmd_set_*_instance,
@@ -858,7 +354,7 @@ mod private
       {
         let mat = m.transform.to_mat3();
         let color = match m.fill { FillRef::Solid( c ) => c, _ => [ 1.0, 1.0, 1.0, 1.0 ] };
-        self.apply_blend( &m.blend );
+        apply_blend( &self.gl, &m.blend );
 
         let mut use_texture = false;
         if let Some( tex_id ) = m.texture && let Some( gpu_tex ) = res.texture( tex_id )
@@ -892,7 +388,7 @@ mod private
       let sprite_size = [ rw, rh ];
 
       let mat = s.transform.to_mat3();
-      self.apply_blend( &s.blend );
+      apply_blend( &self.gl, &s.blend );
       self.sprite.draw( &self.gl, &mat, &uv_rect, &sprite_size, &s.tint, viewport, s.transform.depth );
     }
 
@@ -922,7 +418,15 @@ mod private
       let res = self.resources.borrow();
       if let Some( geom ) = res.geometry( cmd.params.geometry )
       {
-        setup_mesh_batch_vao( gl, &vao, geom, instances.buffer() );
+        setup_mesh_batch_vao
+        (
+          gl,
+          &vao,
+          geom.position_buffer.as_ref(),
+          geom.uv_buffer.as_ref(),
+          geom.index_buffer.as_ref(),
+          instances.buffer(),
+        );
       }
       drop( res );
       self.resources.borrow_mut().store_batch( cmd.batch, GpuBatch::Mesh
@@ -1189,7 +693,15 @@ mod private
             {
               if let Some( geom ) = res.geometry( params.geometry )
               {
-                setup_mesh_batch_vao( &self.gl, vao, geom, instances.buffer() );
+                setup_mesh_batch_vao
+                (
+                  &self.gl,
+                  vao,
+                  geom.position_buffer.as_ref(),
+                  geom.uv_buffer.as_ref(),
+                  geom.index_buffer.as_ref(),
+                  instances.buffer(),
+                );
               }
             }
           }
@@ -1216,7 +728,7 @@ mod private
         );
         return Ok( () );
       };
-      self.apply_blend( match gpu_batch
+      apply_blend( &self.gl, match gpu_batch
       {
         GpuBatch::Sprite { params, .. } => &params.blend,
         GpuBatch::Mesh { params, .. } => &params.blend,
@@ -1365,8 +877,8 @@ mod private
           texture,
           width : Cell::new( w ),
           height : Cell::new( h ),
-          _filter : img.filter,
-          _mipmap : img.mipmap,
+          filter : img.filter,
+          mipmap : img.mipmap,
         });
       }
 
@@ -1510,7 +1022,15 @@ mod private
                   if let GpuBatch::Mesh { vao, params, instances, .. } = batch
                     && params.geometry == id
                   {
-                    setup_mesh_batch_vao( gl, vao, geom, instances.buffer() );
+                    setup_mesh_batch_vao
+                    (
+                      gl,
+                      vao,
+                      geom.position_buffer.as_ref(),
+                      geom.uv_buffer.as_ref(),
+                      geom.index_buffer.as_ref(),
+                      instances.buffer(),
+                    );
                   }
                 }
               }
@@ -1716,32 +1236,6 @@ mod private
   // Shared utilities
   // ============================================================================
 
-  /// Data source that can be sent into a `spawn_local` future.
-  /// Clones the bytes (for `Bytes`) or the path string (for `Path`).
-  enum Loadable
-  {
-    Ready( Vec< u8 > ),
-    Fetch( String ),
-  }
-
-  fn source_to_loadable( source : &crate::assets::Source ) -> Loadable
-  {
-    match source
-    {
-      crate::assets::Source::Bytes( bytes ) => Loadable::Ready( bytes.clone() ),
-      crate::assets::Source::Path( path ) => Loadable::Fetch( path.to_string_lossy().into_owned() ),
-    }
-  }
-
-  async fn resolve_loadable( loadable : Loadable ) -> Option< Vec< u8 > >
-  {
-    match loadable
-    {
-      Loadable::Ready( bytes ) => Some( bytes ),
-      Loadable::Fetch( path ) => gl::file::load( &path ).await.ok(),
-    }
-  }
-
   /// Like `gl::texture::d2::upload_image_from_path`, but updates
   /// `GpuTexture.width` / `height` cells once the image loads.
   fn upload_image_from_path
@@ -1847,63 +1341,11 @@ mod private
 
     texture
   }
-
-  /// Maps a `DataType` to `(bytes_per_index, gl_type_constant)` for `drawElements`.
-  ///
-  /// Returns `Err` for `F32`, which is not a valid WebGL index type.
-  fn index_format( dt : &crate::assets::DataType ) -> Result< ( u32, u32 ), RenderError >
-  {
-    use crate::assets::DataType;
-    match dt
-    {
-      DataType::U8  => Ok( ( 1, gl::UNSIGNED_BYTE ) ),
-      DataType::U16 => Ok( ( 2, gl::UNSIGNED_SHORT ) ),
-      DataType::U32 => Ok( ( 4, gl::UNSIGNED_INT ) ),
-      DataType::F32 => Err( RenderError::BackendError
-      (
-        "GeometryAsset.data_type: F32 is not a valid index format; use U8, U16, or U32".into()
-      )),
-    }
-  }
-
-  /// Sets mag/min filter on the currently bound TEXTURE_2D based on `filter` and `mipmap`.
-  /// Caller is responsible for calling `generate_mipmap` separately when `mipmap != Off`
-  /// (after the level-0 upload completes — on the async path that's inside the on_load callback).
-  fn apply_texture_filter( gl : &gl::GL, filter : &SamplerFilter, mipmap : &MipmapMode )
-  {
-    // mag_filter ignores mipmaps — magnification samples only level 0.
-    let mag = match filter
-    {
-      SamplerFilter::Nearest => gl::NEAREST,
-      SamplerFilter::Linear => gl::LINEAR,
-    };
-    // min_filter combines within-level interpolation with between-level interpolation.
-    let min = match ( filter, mipmap )
-    {
-      ( SamplerFilter::Nearest, MipmapMode::Off )     => gl::NEAREST,
-      ( SamplerFilter::Linear,  MipmapMode::Off )     => gl::LINEAR,
-      ( SamplerFilter::Nearest, MipmapMode::Nearest ) => gl::NEAREST_MIPMAP_NEAREST,
-      ( SamplerFilter::Linear,  MipmapMode::Nearest ) => gl::LINEAR_MIPMAP_NEAREST,
-      ( SamplerFilter::Nearest, MipmapMode::Linear )  => gl::NEAREST_MIPMAP_LINEAR,
-      ( SamplerFilter::Linear,  MipmapMode::Linear )  => gl::LINEAR_MIPMAP_LINEAR,
-    };
-    gl.tex_parameteri( gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, mag as i32 );
-    gl.tex_parameteri( gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, min as i32 );
-  }
-
-  fn topology_to_gl( t : &Topology ) -> u32
-  {
-    match t
-    {
-      Topology::TriangleList => gl::TRIANGLES,
-      Topology::TriangleStrip => gl::TRIANGLE_STRIP,
-      Topology::LineList => gl::LINES,
-      Topology::LineStrip => gl::LINE_STRIP,
-    }
-  }
 }
 
 mod_interface::mod_interface!
 {
+  layer webgl_helpers;
+
   own use WebGlBackend;
 }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -749,18 +749,34 @@ mod private
       {
         // Color: src + dst. Alpha: standard over.
         BlendMode::Add => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
-        // Approximation: equals src*dst only when src_alpha=1.
+        // Approximation: diverges from Photoshop Multiply when src_alpha < 1 — the
+        // DST_COLOR factor multiplies dst by raw src.rgb (not src.rgb*src_a), so
+        // partially transparent sources darken the destination more than the
+        // reference formula prescribes. Exact only when src_alpha = 1.
         // TODO(FBO): replace with Photoshop-accurate formula — see BlendMode::Multiply doc.
         // Color: src*dst + dst*(1-src_a). Alpha: standard over.
         BlendMode::Multiply => gl.blend_func_separate( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
+        // Same class of approximation as Multiply: the ONE / ONE_MINUS_SRC_COLOR
+        // factors use raw src.rgb, so a partially transparent source still
+        // contributes its full (unmultiplied) color. Exact only when src_alpha = 1
+        // or when the source is premultiplied.
         // Color: src + dst*(1-src). Alpha: standard over.
         BlendMode::Screen => gl.blend_func_separate( gl::ONE, gl::ONE_MINUS_SRC_COLOR, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
         // TODO: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
         // expressed as a single blend_func call — it requires a custom shader or a
         // separate FBO read-back pass, neither of which is implemented yet.
-        // Overlay falls back to Normal so rendering is at least visible.
+        // Overlay falls back to Normal so rendering is at least visible; the
+        // console.warn below makes the silent substitution observable.
+        BlendMode::Overlay =>
+        {
+          web_sys::console::warn_1
+          (
+            &"BlendMode::Overlay is not supported in WebGL2 without an FBO pass; falling back to Normal".into()
+          );
+          gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA );
+        }
         // Color: src*src_a + dst*(1-src_a). Alpha: standard over.
-        BlendMode::Normal | BlendMode::Overlay => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
+        BlendMode::Normal => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
       }
     }
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -81,10 +81,6 @@ mod private
     #[ must_use ]
     pub fn is_empty( &self ) -> bool { self.len == 0 }
 
-    /// Current capacity in elements.
-    #[ must_use ]
-    pub fn capacity( &self ) -> u32 { self.capacity }
-
     /// Returns a reference to the underlying `WebGlBuffer`.
     #[ must_use ]
     pub fn buffer( &self ) -> &web_sys::WebGlBuffer { &self.buffer }
@@ -1522,6 +1518,5 @@ mod private
 
 mod_interface::mod_interface!
 {
-  own use ArrayBuffer;
   own use WebGlBackend;
 }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -801,11 +801,11 @@ mod private
       Ok( () )
     }
 
-    fn cmd_set_sprite_instance( &mut self, si : &SetSpriteInstance )
+    fn cmd_set_sprite_instance( &mut self, si : &SetSpriteInstance ) -> Result< (), RenderError >
     {
-      let Some( batch_id ) = self.recording_batch else { return };
+      let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let mut res = self.resources.borrow_mut();
-      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region ) else { return };
+      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region ) else { return Ok( () ) };
       let data = SpriteInstanceData
       {
         transform : si.transform.to_mat3(),
@@ -814,33 +814,62 @@ mod private
       };
       if let Some( GpuBatch::Sprite { instances, .. } ) = res.batch_mut( batch_id )
       {
+        if si.index >= instances.len()
+        {
+          return Err( RenderError::BackendError
+          (
+            format!( "SetSpriteInstance: index {} out of bounds (len {})", si.index, instances.len() )
+          ));
+        }
         instances.set( si.index, &data );
       }
+      Ok( () )
     }
 
-    fn cmd_set_mesh_instance( &mut self, mi : &SetMeshInstance )
+    fn cmd_set_mesh_instance( &mut self, mi : &SetMeshInstance ) -> Result< (), RenderError >
     {
-      let Some( batch_id ) = self.recording_batch else { return };
+      let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let data = MeshInstanceData { transform : mi.transform.to_mat3() };
       let mut res = self.resources.borrow_mut();
       if let Some( GpuBatch::Mesh { instances, .. } ) = res.batch_mut( batch_id )
       {
+        if mi.index >= instances.len()
+        {
+          return Err( RenderError::BackendError
+          (
+            format!( "SetMeshInstance: index {} out of bounds (len {})", mi.index, instances.len() )
+          ));
+        }
         instances.set( mi.index, &data );
       }
+      Ok( () )
     }
 
-    fn cmd_remove_instance( &mut self, ri : &RemoveInstance )
+    fn cmd_remove_instance( &mut self, ri : &RemoveInstance ) -> Result< (), RenderError >
     {
-      let Some( batch_id ) = self.recording_batch else { return };
+      let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let mut res = self.resources.borrow_mut();
       if let Some( batch ) = res.batch_mut( batch_id )
       {
+        let len = match batch
+        {
+          GpuBatch::Sprite { instances, .. } => instances.len(),
+          GpuBatch::Mesh { instances, .. } => instances.len(),
+        };
+        if ri.index >= len
+        {
+          return Err( RenderError::BackendError
+          (
+            format!( "RemoveInstance: index {} out of bounds (len {})", ri.index, len )
+          ));
+        }
         match batch
         {
           GpuBatch::Sprite { instances, .. } => { instances.swap_remove( ri.index ); },
           GpuBatch::Mesh { instances, .. } => { instances.swap_remove( ri.index ); },
         }
       }
+      Ok( () )
     }
 
     fn cmd_set_sprite_batch_params( &mut self, cmd : &SetSpriteBatchParams )
@@ -1212,9 +1241,9 @@ mod private
           RenderCommand::BindBatch( b ) => self.cmd_bind_batch( b )?,
           RenderCommand::AddSpriteInstance( si ) => self.cmd_add_sprite_instance( si )?,
           RenderCommand::AddMeshInstance( mi ) => self.cmd_add_mesh_instance( mi )?,
-          RenderCommand::SetSpriteInstance( si ) => self.cmd_set_sprite_instance( si ),
-          RenderCommand::SetMeshInstance( mi ) => self.cmd_set_mesh_instance( mi ),
-          RenderCommand::RemoveInstance( ri ) => self.cmd_remove_instance( ri ),
+          RenderCommand::SetSpriteInstance( si ) => self.cmd_set_sprite_instance( si )?,
+          RenderCommand::SetMeshInstance( mi ) => self.cmd_set_mesh_instance( mi )?,
+          RenderCommand::RemoveInstance( ri ) => self.cmd_remove_instance( ri )?,
           RenderCommand::SetSpriteBatchParams( sp ) => self.cmd_set_sprite_batch_params( sp ),
           RenderCommand::SetMeshBatchParams( mp ) => self.cmd_set_mesh_batch_params( mp ),
           RenderCommand::UnbindBatch( _ ) => self.cmd_unbind_batch(),

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -343,7 +343,7 @@ mod private
 
   // ---- Instance data for batches ----
 
-  /// Per-instance data for sprite batches (17 floats = 68 bytes).
+  /// Per-instance data for sprite batches (18 floats = 72 bytes).
   #[ repr( C ) ]
   #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
   struct SpriteInstanceData
@@ -351,6 +351,7 @@ mod private
     transform : [ f32; 9 ],
     region : [ f32; 4 ],
     tint : [ f32; 4 ],
+    depth : f32,
   }
 
   impl gl::AsBytes for SpriteInstanceData
@@ -359,12 +360,13 @@ mod private
     fn len( &self ) -> usize { 1 }
   }
 
-  /// Per-instance data for mesh batches (9 floats = 36 bytes).
+  /// Per-instance data for mesh batches (10 floats = 40 bytes).
   #[ repr( C ) ]
   #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
   struct MeshInstanceData
   {
     transform : [ f32; 9 ],
+    depth : f32,
   }
 
   impl gl::AsBytes for MeshInstanceData
@@ -374,8 +376,8 @@ mod private
   }
 
   // Compile-time layout assertions — GPU attrib setup depends on these exact sizes.
-  const _ : () = assert!( core::mem::size_of::< SpriteInstanceData >() == 68 ); // 17 floats × 4
-  const _ : () = assert!( core::mem::size_of::< MeshInstanceData >() == 36 ); // 9 floats × 4
+  const _ : () = assert!( core::mem::size_of::< SpriteInstanceData >() == 72 ); // 18 floats × 4
+  const _ : () = assert!( core::mem::size_of::< MeshInstanceData >() == 40 ); // 10 floats × 4
   const _ : () = assert!( core::mem::align_of::< SpriteInstanceData >() == 4 ); // f32 alignment
   const _ : () = assert!( core::mem::align_of::< MeshInstanceData >() == 4 );
 
@@ -433,11 +435,15 @@ mod private
     gl.enable_vertex_attrib_array( 4 );
     gl.vertex_attrib_pointer_with_i32( 4, 4, gl::FLOAT, false, stride, 52 );
     gl.vertex_attrib_divisor( 4, 1 );
+    // depth: float at location 5, offset 68
+    gl.enable_vertex_attrib_array( 5 );
+    gl.vertex_attrib_pointer_with_i32( 5, 1, gl::FLOAT, false, stride, 68 );
+    gl.vertex_attrib_divisor( 5, 1 );
 
     gl.bind_vertex_array( None );
   }
 
-  /// Sets up a mesh batch VAO with geometry attribs (0–1) and instance attribs (2–4).
+  /// Sets up a mesh batch VAO with geometry attribs (0–1) and instance attribs (2–5).
   fn setup_mesh_batch_vao
   (
     gl : &gl::GL,
@@ -480,6 +486,10 @@ mod private
       gl.vertex_attrib_pointer_with_i32( loc, 3, gl::FLOAT, false, stride, ( i * 12 ) as i32 );
       gl.vertex_attrib_divisor( loc, 1 );
     }
+    // depth: float at location 5, offset 36
+    gl.enable_vertex_attrib_array( 5 );
+    gl.vertex_attrib_pointer_with_i32( 5, 1, gl::FLOAT, false, stride, 36 );
+    gl.vertex_attrib_divisor( 5, 1 );
 
     gl.bind_vertex_array( None );
   }
@@ -516,7 +526,7 @@ mod private
     }
 
     /// Draw a single sprite as a textured quad (triangle strip, 4 vertices from `gl_VertexID`).
-    fn draw( &self, gl : &gl::GL, transform : &[ f32; 9 ], uv_rect : &[ f32; 4 ], sprite_size : &[ f32; 2 ], tint : &[ f32; 4 ], viewport : &[ f32; 2 ] )
+    fn draw( &self, gl : &gl::GL, transform : &[ f32; 9 ], uv_rect : &[ f32; 4 ], sprite_size : &[ f32; 2 ], tint : &[ f32; 4 ], viewport : &[ f32; 2 ], depth : f32 )
     {
       // Unbind any VAO to prevent stale attribute state from interfering
       gl.bind_vertex_array( None );
@@ -526,6 +536,7 @@ mod private
       self.program.uniform_upload( "u_sprite_size", sprite_size );
       self.program.uniform_upload( "u_tint", tint );
       self.program.uniform_upload( "u_viewport", viewport );
+      self.program.uniform_upload( "u_depth", &depth );
       gl.draw_arrays( gl::TRIANGLE_STRIP, 0, 4 );
     }
 
@@ -548,6 +559,7 @@ mod private
       self.batch_program.uniform_upload( "u_tex_size", &[ tw as f32, th as f32 ] );
       let parent_mat = params.transform.to_mat3();
       self.batch_program.uniform_matrix_upload( "u_parent", &parent_mat, true );
+      self.batch_program.uniform_upload( "u_parent_depth", &params.transform.depth );
 
       gl.bind_vertex_array( Some( vao ) );
       gl.draw_arrays_instanced( gl::TRIANGLE_STRIP, 0, 4, instances.len() as i32 );
@@ -599,7 +611,8 @@ mod private
       color : &[ f32; 4 ],
       topology : u32,
       viewport : &[ f32; 2 ],
-      use_texture : bool
+      use_texture : bool,
+      depth : f32,
     )
     {
       self.program.activate();
@@ -607,6 +620,7 @@ mod private
       self.program.uniform_upload( "u_color", color );
       self.program.uniform_upload( "u_viewport", viewport );
       self.program.uniform_upload( "u_use_texture", &i32::from( use_texture ) );
+      self.program.uniform_upload( "u_depth", &depth );
 
       gl.bind_vertex_array( Some( &geom.vao ) );
 
@@ -649,6 +663,7 @@ mod private
       self.batch_program.uniform_upload( "u_use_texture", &i32::from( use_texture ) );
       let parent_mat = params.transform.to_mat3();
       self.batch_program.uniform_matrix_upload( "u_parent", &parent_mat, true );
+      self.batch_program.uniform_upload( "u_parent_depth", &params.transform.depth );
 
       gl.bind_vertex_array( Some( vao ) );
 
@@ -704,6 +719,13 @@ mod private
     /// not by `RenderConfig::antialias`. That field is only meaningful for the SVG adapter.
     /// Pass the desired AA setting when creating the WebGL2 context before calling this.
     ///
+    /// **Depth buffer note:** `DEPTH_TEST` is enabled here so `Transform::depth` takes
+    /// effect (higher → drawn on top). A depth attachment is required; `getContext`
+    /// provides one by default (`depth: true` is the WebGL default). If the context
+    /// was created with `depth: false`, depth testing is silently a no-op. Depth is
+    /// only reliable for fully opaque draws — see `Transform::depth` for the
+    /// transparency caveat.
+    ///
     /// # Errors
     /// Returns error if shader compilation fails.
     pub fn new( config : RenderConfig, gl : gl::GL ) -> Result< Self, RenderError >
@@ -722,6 +744,12 @@ mod private
       // alpha when the canvas is composited against a transparent page or read via
       // readPixels.
       gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA );
+
+      // LEQUAL (not LESS) so equal-depth draws fall back to submission order rather
+      // than rejecting the second one — keeps the default (all depth = 0) case
+      // rendering identically to the pre-depth implementation.
+      gl.enable( gl::DEPTH_TEST );
+      gl.depth_func( gl::LEQUAL );
 
       // Query the actual hardware limit; fall back to the WebGL2 guaranteed minimum.
       // get_parameter returns a JsValue; as_f64() is the idiomatic way to extract it.
@@ -819,7 +847,8 @@ mod private
     {
       let [ r, g, b, a ] = c.color;
       self.gl.clear_color( r, g, b, a );
-      self.gl.clear( gl::COLOR_BUFFER_BIT );
+      self.gl.clear_depth( 1.0 );
+      self.gl.clear( gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT );
     }
 
     fn cmd_mesh( &self, m : &Mesh, viewport : &[ f32; 2 ] )
@@ -839,7 +868,7 @@ mod private
           use_texture = true;
         }
 
-        self.mesh.draw( &self.gl, geom, &mat, &color, topology_to_gl( &m.topology ), viewport, use_texture );
+        self.mesh.draw( &self.gl, geom, &mat, &color, topology_to_gl( &m.topology ), viewport, use_texture, m.transform.depth );
       }
     }
 
@@ -864,7 +893,7 @@ mod private
 
       let mat = s.transform.to_mat3();
       self.apply_blend( &s.blend );
-      self.sprite.draw( &self.gl, &mat, &uv_rect, &sprite_size, &s.tint, viewport );
+      self.sprite.draw( &self.gl, &mat, &uv_rect, &sprite_size, &s.tint, viewport, s.transform.depth );
     }
 
     fn cmd_create_sprite_batch( &mut self, cmd : &CreateSpriteBatch ) -> Result< (), RenderError >
@@ -937,6 +966,7 @@ mod private
         transform : si.transform.to_mat3(),
         region,
         tint : si.tint,
+        depth : si.transform.depth,
       };
       match res.batch_mut( batch_id )
       {
@@ -960,7 +990,7 @@ mod private
     fn cmd_add_mesh_instance( &mut self, mi : &AddMeshInstance ) -> Result< (), RenderError >
     {
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
-      let data = MeshInstanceData { transform : mi.transform.to_mat3() };
+      let data = MeshInstanceData { transform : mi.transform.to_mat3(), depth : mi.transform.depth };
       let mut res = self.resources.borrow_mut();
       match res.batch_mut( batch_id )
       {
@@ -999,6 +1029,7 @@ mod private
         transform : si.transform.to_mat3(),
         region,
         tint : si.tint,
+        depth : si.transform.depth,
       };
       match res.batch_mut( batch_id )
       {
@@ -1031,7 +1062,7 @@ mod private
     fn cmd_set_mesh_instance( &mut self, mi : &SetMeshInstance ) -> Result< (), RenderError >
     {
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
-      let data = MeshInstanceData { transform : mi.transform.to_mat3() };
+      let data = MeshInstanceData { transform : mi.transform.to_mat3(), depth : mi.transform.depth };
       let mut res = self.resources.borrow_mut();
       match res.batch_mut( batch_id )
       {

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1689,7 +1689,11 @@ mod private
         patterns : false,    // TODO: not yet loaded or rendered
         clip_masks : false,  // TODO: not yet loaded or rendered
         effects : false,     // TODO: requires FBO post-processing
-        blend_modes : true,  // Normal/Add/Multiply/Screen work; Overlay falls back to Normal (needs custom shader)
+        // `blend_modes` means "all variants correct"; Overlay silently falls back
+        // to Normal in `apply_blend` (needs FBO / custom shader), so this is false.
+        // Callers needing per-mode info should check `supported_blend_modes`.
+        blend_modes : false,
+        supported_blend_modes : &[ BlendMode::Normal, BlendMode::Add, BlendMode::Multiply, BlendMode::Screen ],
         text_on_path : false,
         max_texture_size : self.max_texture_size,
       }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1259,7 +1259,15 @@ mod private
       .expect( "not an HtmlImageElement" );
     img.style().set_property( "display", "none" ).expect( "can't hide img" );
 
-    let on_load : Closure< dyn Fn() > = Closure::new(
+    // The browser fires `load` XOR `error` exactly once for a given `set_src`
+    // call — there is no retry path here — so FnOnce handlers are the right
+    // shape. `Closure::once_into_js` takes ownership of the Rust closure,
+    // returns a JsValue that we hand to the img element, and arranges for the
+    // captured state (notably the `Rc<RefCell<GpuResources>>` clone in
+    // `on_load`) to be freed after the single invocation, or via finalizer if
+    // the event never fires and the JS function is GC'd. This is what lets a
+    // `WebGlBackend` drop actually release its GPU resources.
+    let on_load = Closure::once_into_js(
     {
       let gl = gl.clone();
       let img = img.clone();
@@ -1303,41 +1311,32 @@ mod private
     });
 
     let src_for_err = src.to_owned();
-    let on_error : Closure< dyn Fn() > = Closure::new( move ||
+    let on_error = Closure::once_into_js(
     {
-      web_sys::console::error_1
-      (
-        &format!( "tilemap_renderer: failed to load image from path {src_for_err:?}" ).into()
-      );
+      let img = img.clone();
+      move ||
+      {
+        web_sys::console::error_1
+        (
+          &format!( "tilemap_renderer: failed to load image from path {src_for_err:?}" ).into()
+        );
+        // Remove the element so the other (never-fired) handler becomes unreachable
+        // and can be GC'd, rather than sitting on a detached img for the lifetime
+        // of the document.
+        img.remove();
+      }
     });
 
-    img.set_onload( Some( on_load.as_ref().unchecked_ref() ) );
-    img.set_onerror( Some( on_error.as_ref().unchecked_ref() ) );
+    img.set_onload( Some( on_load.unchecked_ref() ) );
+    img.set_onerror( Some( on_error.unchecked_ref() ) );
     img.set_src( src );
-    // SAFETY: the browser holds a reference to each closure via the img element's
-    // onload/onerror handlers. Dropping the Closure here would invalidate the JS
-    // function pointer and cause a use-after-free when the browser fires the event.
-    // forget() intentionally leaks the closure so it remains alive for the callback.
-    //
-    // Leak accounting: two closures leak per path-based image per `load_assets`
-    // call (on_load + on_error). Only one of them ever fires, and neither is ever
-    // freed — both persist for the lifetime of the WebGL context. The on_load
-    // closure additionally captures `Rc<RefCell<GpuResources>>`, so its leak
-    // keeps `GpuResources` alive even after the owning `WebGlBackend` is dropped;
-    // every GPU texture / VAO / buffer inside then survives until page close.
-    // on_error only captures a `String` path, so it leaks memory but does not
-    // extend `GpuResources` lifetime.
-    //
-    // For long-lived single-backend apps the drift is small (~KB per image per
-    // reload); for test harnesses or multi-instance hosts that create and drop
-    // `WebGlBackend` it becomes a real resource leak.
-    //
-    // qqq : replace forget() with Closure::once / once_into_js so the browser
-    //       frees each closure after its single invocation. Blocked on refactor
-    //       of the load_assets flow — the current shape expects stable Fn-style
-    //       handlers across retries, which Closure::once cannot provide.
-    on_load.forget();
-    on_error.forget();
+    // `on_load` / `on_error` are `JsValue`s produced by `Closure::once_into_js`.
+    // The img element now holds JS-side references to both functions via its
+    // `onload` / `onerror` properties, so dropping the local JsValue bindings
+    // here does not free the functions. When either event fires, its Rust
+    // closure is dropped (releasing its captures, including the cloned Rc for
+    // `on_load`); the other handler — plus the img itself — becomes GC-eligible
+    // once the fired handler calls `img.remove()` above.
 
     texture
   }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -551,6 +551,11 @@ mod private
 
       gl.bind_vertex_array( Some( vao ) );
       gl.draw_arrays_instanced( gl::TRIANGLE_STRIP, 0, 4, instances.len() as i32 );
+      // Unbind the batch VAO so subsequent GL state setup (e.g. a later
+      // vertex_attrib_pointer call during batch construction) cannot
+      // accidentally mutate this batch's attribute layout. Matches the
+      // single-draw path which also leaves VAO 0 bound.
+      gl.bind_vertex_array( None );
     }
   }
 
@@ -651,6 +656,11 @@ mod private
       {
         gl.draw_arrays_instanced( topology, 0, geom.vertex_count as i32, instances.len() as i32 );
       }
+      // Unbind the batch VAO so subsequent GL state setup (e.g. a later
+      // vertex_attrib_pointer call during batch construction) cannot
+      // accidentally mutate this batch's attribute layout. Matches the
+      // single-draw path which also leaves VAO 0 bound.
+      gl.bind_vertex_array( None );
     }
   }
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1,7 +1,1326 @@
 //! WebGL backend adapter.
 //!
-//! **Status: stub only** — implementation deferred to a follow-up PR.
+//! Hardware-accelerated 2D rendering via WebGL2 (wasm32 target).
+//! Uses `minwebgl` for GL calls. Quad vertices are generated in
+//! the vertex shader via `gl_VertexID` — no quad VAO needed.
 
-mod private {}
+mod private
+{
+  use std::rc::Rc;
+  use std::cell::{ Cell, RefCell };
+  use std::marker::PhantomData;
+  use web_sys::HtmlImageElement;
+  use wasm_bindgen::prelude::*;
+  use minwebgl as gl;
+  use nohash_hasher::IntMap;
+  use crate::assets::Assets;
+  use crate::backend::*;
+  use crate::commands::*;
+  use crate::types::*;
 
-mod_interface::mod_interface! {}
+  // ============================================================================
+  // ArrayBuffer — GPU-side Vec<T>
+  // ============================================================================
+
+  /// GPU array buffer with `Vec`-like semantics.
+  ///
+  /// Stores elements of type `T` in a WebGL `ARRAY_BUFFER`.
+  /// Tracks length and capacity; grows by 2× when full using
+  /// `copy_buffer_sub_data` (GPU-to-GPU, no CPU readback).
+  pub struct ArrayBuffer< T >
+  {
+    gl : gl::GL,
+    buffer : web_sys::WebGlBuffer,
+    len : u32,
+    capacity : u32,
+    _marker : PhantomData< T >,
+  }
+
+  impl< T : gl::AsBytes > ArrayBuffer< T >
+  {
+    /// Creates a new GPU array buffer with the given initial capacity (in elements).
+    pub fn new( gl : &gl::GL, capacity : u32 ) -> Result< Self, gl::WebglError >
+    {
+      let buffer = gl::buffer::create( gl )?;
+      let byte_size = capacity * Self::stride();
+      gl.bind_buffer( gl::ARRAY_BUFFER, Some( &buffer ) );
+      gl.buffer_data_with_i32( gl::ARRAY_BUFFER, byte_size as i32, gl::DYNAMIC_DRAW );
+      gl.bind_buffer( gl::ARRAY_BUFFER, None );
+      Ok( Self { gl : gl.clone(), buffer, len : 0, capacity, _marker : PhantomData } )
+    }
+
+    /// Byte size of one element.
+    fn stride() -> u32
+    {
+      std::mem::size_of::< T >() as u32
+    }
+
+    /// Number of elements currently stored.
+    pub fn len( &self ) -> u32 { self.len }
+
+    /// Whether the buffer is empty.
+    pub fn is_empty( &self ) -> bool { self.len == 0 }
+
+    /// Current capacity in elements.
+    pub fn capacity( &self ) -> u32 { self.capacity }
+
+    /// Returns a reference to the underlying `WebGlBuffer`.
+    pub fn buffer( &self ) -> &web_sys::WebGlBuffer { &self.buffer }
+
+    /// Appends an element at the end, growing if necessary.
+    pub fn push( &mut self, value : &T ) -> Result< (), gl::WebglError >
+    {
+      if self.len >= self.capacity
+      {
+        self.grow()?;
+      }
+      let offset = self.len * Self::stride();
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &self.buffer ) );
+      self.gl.buffer_sub_data_with_i32_and_u8_array( gl::ARRAY_BUFFER, offset as i32, value.as_bytes() );
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
+      self.len += 1;
+      Ok( () )
+    }
+
+    /// Updates the element at `index` in-place.
+    ///
+    /// # Panics
+    /// Panics if `index >= len`.
+    pub fn set( &self, index : u32, value : &T )
+    {
+      assert!( index < self.len, "ArrayBuffer::set index out of bounds" );
+      let offset = index * Self::stride();
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &self.buffer ) );
+      self.gl.buffer_sub_data_with_i32_and_u8_array( gl::ARRAY_BUFFER, offset as i32, value.as_bytes() );
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
+    }
+
+    /// Removes the element at `index` by swapping with the last element.
+    /// Returns the new length.
+    pub fn swap_remove( &mut self, index : u32 ) -> u32
+    {
+      assert!( index < self.len, "ArrayBuffer::swap_remove index out of bounds" );
+      self.len -= 1;
+      if index < self.len
+      {
+        let stride = Self::stride() as i32;
+        let src_offset = self.len as i32 * stride;
+        let dst_offset = index as i32 * stride;
+
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.buffer ) );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &self.buffer ) );
+        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
+        (
+          gl::COPY_READ_BUFFER,
+          gl::COPY_WRITE_BUFFER,
+          src_offset,
+          dst_offset,
+          stride,
+        );
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, None );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, None );
+      }
+      self.len
+    }
+
+    /// Doubles the capacity, copying old data GPU-to-GPU.
+    fn grow( &mut self ) -> Result< (), gl::WebglError >
+    {
+      let new_capacity = if self.capacity == 0 { 4 } else { self.capacity * 2 };
+      let new_byte_size = new_capacity * Self::stride();
+
+      let new_buffer = gl::buffer::create( &self.gl )?;
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &new_buffer ) );
+      self.gl.buffer_data_with_i32( gl::ARRAY_BUFFER, new_byte_size as i32, gl::DYNAMIC_DRAW );
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
+
+      if self.len > 0
+      {
+        let copy_bytes = self.len * Self::stride();
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.buffer ) );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &new_buffer ) );
+        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
+        (
+          gl::COPY_READ_BUFFER,
+          gl::COPY_WRITE_BUFFER,
+          0,
+          0,
+          copy_bytes as i32,
+        );
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, None );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, None );
+      }
+
+      self.gl.delete_buffer( Some( &self.buffer ) );
+      self.buffer = new_buffer;
+      self.capacity = new_capacity;
+      Ok( () )
+    }
+  }
+
+  impl< T > Drop for ArrayBuffer< T >
+  {
+    fn drop( &mut self )
+    {
+      self.gl.delete_buffer( Some( &self.buffer ) );
+    }
+  }
+
+  // ============================================================================
+  // GPU resource handles
+  // ============================================================================
+
+  /// Manages GPU-side resources: textures and geometry buffers.
+  struct GpuResources
+  {
+    textures : IntMap< ResourceId< asset::Image >, GpuTexture >,
+    sprites : IntMap< ResourceId< asset::Sprite >, GpuSprite >,
+    geometries : IntMap< ResourceId< asset::Geometry >, GpuGeometry >,
+    batches : IntMap< ResourceId< Batch >, GpuBatch >,
+  }
+
+  impl GpuResources
+  {
+    fn new() -> Self
+    {
+      Self
+      {
+        textures : IntMap::default(),
+        sprites : IntMap::default(),
+        geometries : IntMap::default(),
+        batches : IntMap::default(),
+      }
+    }
+
+    fn texture( &self, id : ResourceId< asset::Image > ) -> Option< &GpuTexture >
+    {
+      self.textures.get( &id )
+    }
+
+    fn sprite( &self, id : ResourceId< asset::Sprite > ) -> Option< &GpuSprite >
+    {
+      self.sprites.get( &id )
+    }
+
+    fn geometry( &self, id : ResourceId< asset::Geometry > ) -> Option< &GpuGeometry >
+    {
+      self.geometries.get( &id )
+    }
+
+    fn batch( &self, id : ResourceId< Batch > ) -> Option< &GpuBatch >
+    {
+      self.batches.get( &id )
+    }
+
+    fn batch_mut( &mut self, id : ResourceId< Batch > ) -> Option< &mut GpuBatch >
+    {
+      self.batches.get_mut( &id )
+    }
+
+    fn store_texture( &mut self, id : ResourceId< asset::Image >, tex : GpuTexture )
+    {
+      self.textures.insert( id, tex );
+    }
+
+    fn store_sprite( &mut self, id : ResourceId< asset::Sprite >, sprite : GpuSprite )
+    {
+      self.sprites.insert( id, sprite );
+    }
+
+    fn store_geometry( &mut self, id : ResourceId< asset::Geometry >, geom : GpuGeometry )
+    {
+      self.geometries.insert( id, geom );
+    }
+
+    fn store_batch( &mut self, id : ResourceId< Batch >, batch : GpuBatch )
+    {
+      self.batches.insert( id, batch );
+    }
+  }
+
+  struct GpuTexture
+  {
+    gl : gl::GL,
+    texture : web_sys::WebGlTexture,
+    width : Cell< u32 >,
+    height : Cell< u32 >,
+    _filter : SamplerFilter,
+  }
+
+  impl Drop for GpuTexture
+  {
+    fn drop( &mut self )
+    {
+      self.gl.delete_texture( Some( &self.texture ) );
+    }
+  }
+
+  /// Sprite lookup data: sheet reference + pixel region.
+  /// UV rect and size are computed at draw time from the sheet's dimensions.
+  struct GpuSprite
+  {
+    /// Sheet texture to bind.
+    sheet : ResourceId< asset::Image >,
+    /// Region within the sheet: `[x, y, w, h]` in pixels.
+    region : [ f32; 4 ],
+  }
+
+  struct GpuGeometry
+  {
+    gl : gl::GL,
+    vao : web_sys::WebGlVertexArrayObject,
+    position_buffer : Option< web_sys::WebGlBuffer >,
+    uv_buffer : Option< web_sys::WebGlBuffer >,
+    index_buffer : Option< web_sys::WebGlBuffer >,
+    vertex_count : u32,
+    index_count : Option< u32 >,
+  }
+
+  impl Drop for GpuGeometry
+  {
+    fn drop( &mut self )
+    {
+      self.gl.delete_vertex_array( Some( &self.vao ) );
+      if let Some( ref buf ) = self.position_buffer { self.gl.delete_buffer( Some( buf ) ); }
+      if let Some( ref buf ) = self.uv_buffer { self.gl.delete_buffer( Some( buf ) ); }
+      if let Some( ref buf ) = self.index_buffer { self.gl.delete_buffer( Some( buf ) ); }
+    }
+  }
+
+  // ---- Instance data for batches ----
+
+  /// Per-instance data for sprite batches (17 floats = 68 bytes).
+  #[ repr( C ) ]
+  #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
+  struct SpriteInstanceData
+  {
+    transform : [ f32; 9 ],
+    region : [ f32; 4 ],
+    tint : [ f32; 4 ],
+  }
+
+  impl gl::AsBytes for SpriteInstanceData
+  {
+    fn as_bytes( &self ) -> &[ u8 ] { bytemuck::bytes_of( self ) }
+    fn len( &self ) -> usize { 1 }
+  }
+
+  /// Per-instance data for mesh batches (9 floats = 36 bytes).
+  #[ repr( C ) ]
+  #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
+  struct MeshInstanceData
+  {
+    transform : [ f32; 9 ],
+  }
+
+  impl gl::AsBytes for MeshInstanceData
+  {
+    fn as_bytes( &self ) -> &[ u8 ] { bytemuck::bytes_of( self ) }
+    fn len( &self ) -> usize { 1 }
+  }
+
+  // Compile-time layout assertions — GPU attrib setup depends on these exact sizes.
+  const _ : () = assert!( std::mem::size_of::< SpriteInstanceData >() == 68 ); // 17 floats × 4
+  const _ : () = assert!( std::mem::size_of::< MeshInstanceData >() == 36 ); // 9 floats × 4
+  const _ : () = assert!( std::mem::align_of::< SpriteInstanceData >() == 4 ); // f32 alignment
+  const _ : () = assert!( std::mem::align_of::< MeshInstanceData >() == 4 );
+
+  /// Persistent batch — sprite or mesh.
+  enum GpuBatch
+  {
+    Sprite
+    {
+      instances : ArrayBuffer< SpriteInstanceData >,
+      vao : web_sys::WebGlVertexArrayObject,
+      params : SpriteBatchParams,
+    },
+    Mesh
+    {
+      instances : ArrayBuffer< MeshInstanceData >,
+      vao : web_sys::WebGlVertexArrayObject,
+      params : MeshBatchParams,
+    },
+  }
+
+  /// Binds instance attrib pointers for a sprite batch VAO.
+  fn setup_sprite_batch_vao( gl : &gl::GL, vao : &web_sys::WebGlVertexArrayObject, buffer : &web_sys::WebGlBuffer )
+  {
+    gl.bind_vertex_array( Some( vao ) );
+    gl.bind_buffer( gl::ARRAY_BUFFER, Some( buffer ) );
+
+    let stride = std::mem::size_of::< SpriteInstanceData >() as i32;
+
+    // transform: 3 × vec3 at locations 0, 1, 2
+    for i in 0..3_u32
+    {
+      gl.enable_vertex_attrib_array( i );
+      gl.vertex_attrib_pointer_with_i32( i, 3, gl::FLOAT, false, stride, ( i * 12 ) as i32 );
+      gl.vertex_attrib_divisor( i, 1 );
+    }
+    // region: vec4 at location 3, offset 36
+    gl.enable_vertex_attrib_array( 3 );
+    gl.vertex_attrib_pointer_with_i32( 3, 4, gl::FLOAT, false, stride, 36 );
+    gl.vertex_attrib_divisor( 3, 1 );
+    // tint: vec4 at location 4, offset 52
+    gl.enable_vertex_attrib_array( 4 );
+    gl.vertex_attrib_pointer_with_i32( 4, 4, gl::FLOAT, false, stride, 52 );
+    gl.vertex_attrib_divisor( 4, 1 );
+
+    gl.bind_vertex_array( None );
+  }
+
+  /// Sets up a mesh batch VAO with geometry attribs (0–1) and instance attribs (2–4).
+  fn setup_mesh_batch_vao
+  (
+    gl : &gl::GL,
+    vao : &web_sys::WebGlVertexArrayObject,
+    geom : &GpuGeometry,
+    instance_buffer : &web_sys::WebGlBuffer,
+  )
+  {
+    gl.bind_vertex_array( Some( vao ) );
+
+    // Geometry: positions (attrib 0)
+    if let Some( ref buf ) = geom.position_buffer
+    {
+      gl.bind_buffer( gl::ARRAY_BUFFER, Some( buf ) );
+      gl.enable_vertex_attrib_array( 0 );
+      gl.vertex_attrib_pointer_with_i32( 0, 2, gl::FLOAT, false, 0, 0 );
+    }
+
+    // Geometry: UVs (attrib 1)
+    if let Some( ref buf ) = geom.uv_buffer
+    {
+      gl.bind_buffer( gl::ARRAY_BUFFER, Some( buf ) );
+      gl.enable_vertex_attrib_array( 1 );
+      gl.vertex_attrib_pointer_with_i32( 1, 2, gl::FLOAT, false, 0, 0 );
+    }
+
+    // Geometry: indices
+    if let Some( ref buf ) = geom.index_buffer
+    {
+      gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( buf ) );
+    }
+
+    // Instance: transform 3 × vec3 at locations 2, 3, 4
+    gl.bind_buffer( gl::ARRAY_BUFFER, Some( instance_buffer ) );
+    let stride = std::mem::size_of::< MeshInstanceData >() as i32;
+    for i in 0..3_u32
+    {
+      let loc = i + 2;
+      gl.enable_vertex_attrib_array( loc );
+      gl.vertex_attrib_pointer_with_i32( loc, 3, gl::FLOAT, false, stride, ( i * 12 ) as i32 );
+      gl.vertex_attrib_divisor( loc, 1 );
+    }
+
+    gl.bind_vertex_array( None );
+  }
+
+  // ============================================================================
+  // Sprite renderer
+  // ============================================================================
+
+  /// Handles single sprite draws and sprite batch instancing.
+  /// Quad is generated in vertex shader from `gl_VertexID` (triangle strip, 4 vertices).
+  struct SpriteRenderer
+  {
+    program : gl::Program,
+    batch_program : gl::Program,
+  }
+
+  impl SpriteRenderer
+  {
+    fn new( gl : &gl::GL ) -> Result< Self, gl::WebglError >
+    {
+      let program = gl::Program::new
+      (
+        gl.clone(),
+        include_str!( "shaders/sprite.vert" ),
+        include_str!( "shaders/sprite.frag" ),
+      )?;
+      let batch_program = gl::Program::new
+      (
+        gl.clone(),
+        include_str!( "shaders/sprite_batch.vert" ),
+        include_str!( "shaders/sprite_batch.frag" ),
+      )?;
+      Ok( Self { program, batch_program } )
+    }
+
+    /// Draw a single sprite as a textured quad (triangle strip, 4 vertices from gl_VertexID).
+    fn draw( &self, gl : &gl::GL, transform : &[ f32; 9 ], uv_rect : &[ f32; 4 ], sprite_size : &[ f32; 2 ], tint : &[ f32; 4 ], viewport : &[ f32; 2 ] )
+    {
+      // Unbind any VAO to prevent stale attribute state from interfering
+      gl.bind_vertex_array( None );
+      self.program.activate();
+      self.program.uniform_matrix_upload( "u_transform", transform.as_slice(), true );
+      self.program.uniform_upload( "u_uv_rect", uv_rect );
+      self.program.uniform_upload( "u_sprite_size", sprite_size );
+      self.program.uniform_upload( "u_tint", tint );
+      self.program.uniform_upload( "u_viewport", viewport );
+      gl.draw_arrays( gl::TRIANGLE_STRIP, 0, 4 );
+    }
+
+    /// Draw an instanced sprite batch.
+    fn draw_batch( &self, gl : &gl::GL, batch : &GpuBatch, resources : &GpuResources, viewport : &[ f32; 2 ] )
+    {
+      let GpuBatch::Sprite { instances, vao, params } = batch else { return; };
+      if instances.is_empty() { return; }
+
+      let Some( gpu_tex ) = resources.texture( params.sheet ) else { return; };
+      let tw = gpu_tex.width.get();
+      let th = gpu_tex.height.get();
+      if tw == 0 || th == 0 { return; }
+
+      gl.active_texture( gl::TEXTURE0 );
+      gl.bind_texture( gl::TEXTURE_2D, Some( &gpu_tex.texture ) );
+
+      self.batch_program.activate();
+      self.batch_program.uniform_upload( "u_viewport", viewport );
+      self.batch_program.uniform_upload( "u_tex_size", &[ tw as f32, th as f32 ] );
+      let parent_mat = params.transform.to_mat3();
+      self.batch_program.uniform_matrix_upload( "u_parent", &parent_mat, true );
+
+      gl.bind_vertex_array( Some( vao ) );
+      gl.draw_arrays_instanced( gl::TRIANGLE_STRIP, 0, 4, instances.len() as i32 );
+    }
+  }
+
+  // ============================================================================
+  // Mesh renderer
+  // ============================================================================
+
+  /// Handles single mesh draws and mesh batch instancing.
+  struct MeshRenderer
+  {
+    program : gl::Program,
+    batch_program : gl::Program,
+  }
+
+  impl MeshRenderer
+  {
+    fn new( gl : &gl::GL ) -> Result< Self, gl::WebglError >
+    {
+      let program = gl::Program::new
+      (
+        gl.clone(),
+        include_str!( "shaders/mesh.vert" ),
+        include_str!( "shaders/mesh.frag" ),
+      )?;
+      let batch_program = gl::Program::new
+      (
+        gl.clone(),
+        include_str!( "shaders/mesh_batch.vert" ),
+        include_str!( "shaders/mesh.frag" ),
+      )?;
+      Ok( Self { program, batch_program } )
+    }
+
+    /// Draw a single mesh.
+    fn draw
+    (
+      &self,
+      gl : &gl::GL,
+      geom : &GpuGeometry,
+      transform : &[ f32; 9 ],
+      color : &[ f32; 4 ],
+      topology : u32,
+      viewport : &[ f32; 2 ],
+      use_texture : bool
+    )
+    {
+      self.program.activate();
+      self.program.uniform_matrix_upload( "u_transform", transform.as_slice(), true );
+      self.program.uniform_upload( "u_color", color );
+      self.program.uniform_upload( "u_viewport", viewport );
+      self.program.uniform_upload( "u_use_texture", &( use_texture as i32 ) );
+
+      gl.bind_vertex_array( Some( &geom.vao ) );
+
+      if let Some( count ) = geom.index_count
+      {
+        gl.draw_elements_with_i32( topology, count as i32, gl::UNSIGNED_SHORT, 0 );
+      }
+      else
+      {
+        gl.draw_arrays( topology, 0, geom.vertex_count as i32 );
+      }
+    }
+
+    /// Draw an instanced mesh batch. VAO is already configured via `setup_mesh_batch_vao`.
+    fn draw_batch( &self, gl : &gl::GL, batch : &GpuBatch, resources : &GpuResources, viewport : &[ f32; 2 ] )
+    {
+      let GpuBatch::Mesh { instances, vao, params } = batch else { return };
+      if instances.is_empty() { return; }
+
+      let Some( geom ) = resources.geometry( params.geometry ) else { return };
+      let color = match params.fill { FillRef::Solid( c ) => c, _ => [ 1.0, 1.0, 1.0, 1.0 ] };
+      let topology = topology_to_gl( &params.topology );
+
+      let mut use_texture = false;
+      if let Some( tex_id ) = params.texture
+      {
+        if let Some( gpu_tex ) = resources.texture( tex_id )
+        {
+          gl.active_texture( gl::TEXTURE0 );
+          gl.bind_texture( gl::TEXTURE_2D, Some( &gpu_tex.texture ) );
+          use_texture = true;
+        }
+      }
+
+      self.batch_program.activate();
+      self.batch_program.uniform_upload( "u_viewport", viewport );
+      self.batch_program.uniform_upload( "u_color", &color );
+      self.batch_program.uniform_upload( "u_use_texture", &( use_texture as i32 ) );
+      let parent_mat = params.transform.to_mat3();
+      self.batch_program.uniform_matrix_upload( "u_parent", &parent_mat, true );
+
+      gl.bind_vertex_array( Some( vao ) );
+
+      if let Some( count ) = geom.index_count
+      {
+        gl.draw_elements_instanced_with_i32( topology, count as i32, gl::UNSIGNED_SHORT, 0, instances.len() as i32 );
+      }
+      else
+      {
+        gl.draw_arrays_instanced( topology, 0, geom.vertex_count as i32, instances.len() as i32 );
+      }
+    }
+  }
+
+  // ============================================================================
+  // Backend struct
+  // ============================================================================
+
+  /// WebGL renderer backend.
+  ///
+  /// ```ignore
+  /// let config = RenderConfig { width: 800, height: 600, ..Default::default() };
+  /// let gl_ctx = minwebgl::context::from_canvas( &canvas )?;
+  /// let mut backend = WebGlBackend::new( config, gl_ctx )?;
+  /// backend.load_assets( &assets )?;
+  /// backend.submit( &commands )?;
+  /// ```
+  pub struct WebGlBackend
+  {
+    config : RenderConfig,
+    gl : gl::GL,
+    resources : Rc< RefCell< GpuResources > >,
+    sprite : SpriteRenderer,
+    mesh : MeshRenderer,
+
+    // -- batch editing state --
+    recording_batch : Option< ResourceId< Batch > >,
+  }
+
+  impl WebGlBackend
+  {
+    /// Creates a new WebGL backend.
+    ///
+    /// # Errors
+    /// Returns error if shader compilation fails.
+    pub fn new( config : RenderConfig, gl : gl::GL ) -> Result< Self, RenderError >
+    {
+      let map_err = | e : gl::WebglError | RenderError::BackendError( format!( "{e:?}" ) );
+
+      let sprite = SpriteRenderer::new( &gl ).map_err( map_err )?;
+      let mesh = MeshRenderer::new( &gl ).map_err( map_err )?;
+
+      // Initial GL state
+      gl.viewport( 0, 0, config.width as i32, config.height as i32 );
+      gl.enable( gl::BLEND );
+      gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA );
+
+      if !matches!( config.antialias, Antialias::None )
+      {
+        gl.enable( gl::SAMPLE_COVERAGE );
+      }
+
+      Ok( Self
+      {
+        config,
+        gl,
+        resources : Rc::new( RefCell::new( GpuResources::new() ) ),
+        sprite,
+        mesh,
+        recording_batch : None,
+      })
+    }
+
+    fn viewport_size( &self ) -> [ f32; 2 ]
+    {
+      [ self.config.width as f32, self.config.height as f32 ]
+    }
+
+    // ---- Blend ----
+
+    fn apply_blend( &self, blend : &BlendMode )
+    {
+      let gl = &self.gl;
+      match blend
+      {
+        BlendMode::Normal => gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA ),
+        BlendMode::Add => gl.blend_func( gl::SRC_ALPHA, gl::ONE ),
+        BlendMode::Multiply => gl.blend_func( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA ),
+        BlendMode::Screen => gl.blend_func( gl::ONE, gl::ONE_MINUS_SRC_COLOR ),
+        BlendMode::Overlay => gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA ),
+      }
+    }
+
+    // ---- Command handlers ----
+
+    fn cmd_clear( &self, c : &Clear )
+    {
+      let [ r, g, b, a ] = c.color;
+      self.gl.clear_color( r, g, b, a );
+      self.gl.clear( gl::COLOR_BUFFER_BIT );
+    }
+
+    fn cmd_mesh( &self, m : &Mesh, viewport : &[ f32; 2 ] )
+    {
+      let res = self.resources.borrow();
+      if let Some( geom ) = res.geometry( m.geometry )
+      {
+        let mat = m.transform.to_mat3();
+        let color = match m.fill { FillRef::Solid( c ) => c, _ => [ 1.0, 1.0, 1.0, 1.0 ] };
+        self.apply_blend( &m.blend );
+
+        let mut use_texture = false;
+        if let Some( tex_id ) = m.texture && let Some( gpu_tex ) = res.texture( tex_id )
+        {
+          self.gl.active_texture( gl::TEXTURE0 );
+          self.gl.bind_texture( gl::TEXTURE_2D, Some( &gpu_tex.texture ) );
+          use_texture = true;
+        }
+
+        self.mesh.draw( &self.gl, geom, &mat, &color, topology_to_gl( &m.topology ), viewport, use_texture );
+      }
+    }
+
+    fn cmd_sprite( &self, s : &Sprite, viewport : &[ f32; 2 ] )
+    {
+      let res = self.resources.borrow();
+      let Some( gpu_sprite ) = res.sprite( s.sprite ) else { return };
+      let Some( gpu_tex ) = res.texture( gpu_sprite.sheet ) else { return };
+
+      let tw = gpu_tex.width.get();
+      let th = gpu_tex.height.get();
+      if tw == 0 || th == 0 { return; } // image not loaded yet
+
+      self.gl.active_texture( gl::TEXTURE0 );
+      self.gl.bind_texture( gl::TEXTURE_2D, Some( &gpu_tex.texture ) );
+
+      let [ rx, ry, rw, rh ] = gpu_sprite.region;
+      let tw = tw as f32;
+      let th = th as f32;
+      let uv_rect = [ rx / tw, ry / th, rw / tw, rh / th ];
+      let sprite_size = [ rw, rh ];
+
+      let mat = s.transform.to_mat3();
+      self.apply_blend( &s.blend );
+      self.sprite.draw( &self.gl, &mat, &uv_rect, &sprite_size, &s.tint, viewport );
+    }
+
+    fn cmd_create_sprite_batch( &mut self, cmd : &CreateSpriteBatch )
+    {
+      let gl = &self.gl;
+      let Ok( instances ) = ArrayBuffer::< SpriteInstanceData >::new( gl, 16 ) else { return };
+      let Ok( vao ) = gl::vao::create( gl ) else { return };
+      setup_sprite_batch_vao( gl, &vao, instances.buffer() );
+      self.resources.borrow_mut().store_batch( cmd.batch, GpuBatch::Sprite
+      {
+        instances,
+        vao,
+        params : cmd.params,
+      });
+    }
+
+    fn cmd_create_mesh_batch( &mut self, cmd : &CreateMeshBatch )
+    {
+      let gl = &self.gl;
+      let Ok( instances ) = ArrayBuffer::< MeshInstanceData >::new( gl, 16 ) else { return };
+      let Ok( vao ) = gl::vao::create( gl ) else { return };
+      let res = self.resources.borrow();
+      if let Some( geom ) = res.geometry( cmd.params.geometry )
+      {
+        setup_mesh_batch_vao( gl, &vao, geom, instances.buffer() );
+      }
+      drop( res );
+      self.resources.borrow_mut().store_batch( cmd.batch, GpuBatch::Mesh
+      {
+        instances,
+        vao,
+        params : cmd.params,
+      });
+    }
+
+    fn cmd_bind_batch( &mut self, cmd : &BindBatch )
+    {
+      self.recording_batch = Some( cmd.batch );
+    }
+
+    fn cmd_add_sprite_instance( &mut self, si : &AddSpriteInstance )
+    {
+      let Some( batch_id ) = self.recording_batch else { return };
+      let mut res = self.resources.borrow_mut();
+      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region ) else { return };
+      let data = SpriteInstanceData
+      {
+        transform : si.transform.to_mat3(),
+        region,
+        tint : si.tint,
+      };
+      if let Some( GpuBatch::Sprite { instances, .. } ) = res.batch_mut( batch_id )
+      {
+        let _ = instances.push( &data );
+      }
+    }
+
+    fn cmd_add_mesh_instance( &mut self, mi : &AddMeshInstance )
+    {
+      let Some( batch_id ) = self.recording_batch else { return };
+      let data = MeshInstanceData { transform : mi.transform.to_mat3() };
+      let mut res = self.resources.borrow_mut();
+      if let Some( GpuBatch::Mesh { instances, .. } ) = res.batch_mut( batch_id )
+      {
+        let _ = instances.push( &data );
+      }
+    }
+
+    fn cmd_set_sprite_instance( &mut self, si : &SetSpriteInstance )
+    {
+      let Some( batch_id ) = self.recording_batch else { return };
+      let mut res = self.resources.borrow_mut();
+      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region ) else { return };
+      let data = SpriteInstanceData
+      {
+        transform : si.transform.to_mat3(),
+        region,
+        tint : si.tint,
+      };
+      if let Some( GpuBatch::Sprite { instances, .. } ) = res.batch_mut( batch_id )
+      {
+        instances.set( si.index, &data );
+      }
+    }
+
+    fn cmd_set_mesh_instance( &mut self, mi : &SetMeshInstance )
+    {
+      let Some( batch_id ) = self.recording_batch else { return };
+      let data = MeshInstanceData { transform : mi.transform.to_mat3() };
+      let mut res = self.resources.borrow_mut();
+      if let Some( GpuBatch::Mesh { instances, .. } ) = res.batch_mut( batch_id )
+      {
+        instances.set( mi.index, &data );
+      }
+    }
+
+    fn cmd_remove_instance( &mut self, ri : &RemoveInstance )
+    {
+      let Some( batch_id ) = self.recording_batch else { return };
+      let mut res = self.resources.borrow_mut();
+      if let Some( batch ) = res.batch_mut( batch_id )
+      {
+        match batch
+        {
+          GpuBatch::Sprite { instances, .. } => { instances.swap_remove( ri.index ); },
+          GpuBatch::Mesh { instances, .. } => { instances.swap_remove( ri.index ); },
+        }
+      }
+    }
+
+    fn cmd_set_sprite_batch_params( &mut self, cmd : &SetSpriteBatchParams )
+    {
+      let Some( batch_id ) = self.recording_batch else { return };
+      let mut res = self.resources.borrow_mut();
+      if let Some( GpuBatch::Sprite { params, .. } ) = res.batch_mut( batch_id )
+      {
+        *params = cmd.params;
+      }
+    }
+
+    fn cmd_set_mesh_batch_params( &mut self, cmd : &SetMeshBatchParams )
+    {
+      let Some( batch_id ) = self.recording_batch else { return };
+      let mut res = self.resources.borrow_mut();
+      if let Some( GpuBatch::Mesh { params, .. } ) = res.batch_mut( batch_id )
+      {
+        *params = cmd.params;
+      }
+    }
+
+    fn cmd_unbind_batch( &mut self )
+    {
+      if let Some( batch_id ) = self.recording_batch.take()
+      {
+        let res = self.resources.borrow();
+        if let Some( batch ) = res.batch( batch_id )
+        {
+          match batch
+          {
+            GpuBatch::Sprite { instances, vao, .. } =>
+            {
+              setup_sprite_batch_vao( &self.gl, vao, instances.buffer() );
+            }
+            GpuBatch::Mesh { instances, vao, params } =>
+            {
+              if let Some( geom ) = res.geometry( params.geometry )
+              {
+                setup_mesh_batch_vao( &self.gl, vao, geom, instances.buffer() );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    fn cmd_draw_batch( &self, db : &DrawBatch, viewport : &[ f32; 2 ] )
+    {
+      let res = self.resources.borrow();
+      if let Some( gpu_batch ) = res.batch( db.batch )
+      {
+        self.apply_blend( match gpu_batch
+        {
+          GpuBatch::Sprite { params, .. } => &params.blend,
+          GpuBatch::Mesh { params, .. } => &params.blend,
+        });
+        match gpu_batch
+        {
+          GpuBatch::Sprite { .. } => self.sprite.draw_batch( &self.gl, gpu_batch, &res, viewport ),
+          GpuBatch::Mesh { .. } => self.mesh.draw_batch( &self.gl, gpu_batch, &res, viewport ),
+        }
+      }
+    }
+
+    fn cmd_delete_batch( &mut self, db : &DeleteBatch )
+    {
+      // ArrayBuffer::drop handles GPU buffer cleanup
+      self.resources.borrow_mut().batches.remove( &db.batch );
+    }
+
+    // ---- Asset loading ----
+
+    fn load_images( &mut self, images : &[ crate::assets::ImageAsset ] ) -> Result< (), RenderError >
+    {
+      let gl = &self.gl;
+      self.resources.borrow_mut().textures.clear();
+
+      for img in images
+      {
+        let ( texture, w, h ) = match &img.source
+        {
+          crate::assets::ImageSource::Bitmap { bytes, width, height, format } =>
+          {
+            let tex = gl.create_texture()
+            .ok_or_else( || RenderError::BackendError( "failed to create texture".into() ) )?;
+
+            gl.bind_texture( gl::TEXTURE_2D, Some( &tex ) );
+
+            let gl_fmt = match format
+            {
+              crate::assets::PixelFormat::Rgba8 => gl::RGBA,
+              crate::assets::PixelFormat::Rgb8 => gl::RGB,
+              crate::assets::PixelFormat::Gray8 => gl::LUMINANCE,
+              crate::assets::PixelFormat::GrayAlpha8 => gl::LUMINANCE_ALPHA,
+            };
+
+            let _ = gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array
+            (
+              gl::TEXTURE_2D, 0, gl_fmt as i32,
+              *width as i32, *height as i32, 0,
+              gl_fmt, gl::UNSIGNED_BYTE, Some( bytes ),
+            );
+
+            ( tex, *width, *height )
+          }
+          crate::assets::ImageSource::Encoded( _ ) => { continue; } // TODO: decode
+          crate::assets::ImageSource::Path( path ) =>
+          {
+            let path = path.as_path().to_str()
+              .ok_or_else( || RenderError::BackendError( "non-UTF-8 image path".into() ) )?;
+            let tex = upload_image_from_path( gl, path, img.id, &self.resources );
+            gl.bind_texture( gl::TEXTURE_2D, Some( &tex ) );
+            ( tex, 0, 0 )
+          }
+        };
+
+        apply_texture_filter( gl, &img.filter );
+        gl::texture::d2::wrap_clamp( gl );
+
+        self.resources.borrow_mut().store_texture( img.id, GpuTexture
+        {
+          gl : gl.clone(),
+          texture,
+          width : Cell::new( w ),
+          height : Cell::new( h ),
+          _filter : img.filter,
+        });
+      }
+
+      Ok( () )
+    }
+
+    fn load_sprites( &mut self, sprites : &[ crate::assets::SpriteAsset ] )
+    {
+      self.resources.borrow_mut().sprites.clear();
+
+      for spr in sprites
+      {
+        self.resources.borrow_mut().store_sprite( spr.id, GpuSprite
+        {
+          sheet : spr.sheet,
+          region : spr.region,
+        });
+      }
+    }
+
+    fn load_geometries( &mut self, geometries : &[ crate::assets::GeometryAsset ] ) -> Result< (), RenderError >
+    {
+      let gl = &self.gl;
+      let map_err = | e : gl::WebglError | RenderError::BackendError( format!( "{e:?}" ) );
+      self.resources.borrow_mut().geometries.clear();
+
+      for geom in geometries
+      {
+        let has_path =
+          matches!( geom.positions, crate::assets::Source::Path( _ ) )
+          || matches!( geom.uvs, Some( crate::assets::Source::Path( _ ) ) )
+          || matches!( geom.indices, Some( crate::assets::Source::Path( _ ) ) );
+
+        if has_path
+        {
+          // Create empty VAO and register geometry immediately so the id is available.
+          // The spawn_local future will fetch data and populate the VAO later.
+          let vao = gl::vao::create( gl ).map_err( map_err )?;
+          self.resources.borrow_mut().store_geometry( geom.id, GpuGeometry
+          {
+            gl : gl.clone(), vao : vao.clone(), position_buffer : None, uv_buffer : None, index_buffer : None,
+            vertex_count : 0, index_count : None,
+          });
+
+          let gl_clone = gl.clone();
+          let resources = Rc::clone( &self.resources );
+          let id = geom.id;
+
+          let positions_source = source_to_loadable( &geom.positions );
+          let uvs_source = geom.uvs.as_ref().map( source_to_loadable );
+          let indices_source = geom.indices.as_ref().map( source_to_loadable );
+
+          gl::spawn_local( async move
+          {
+            let gl = &gl_clone;
+
+            let positions = resolve_loadable( positions_source ).await;
+            let uvs = match uvs_source { Some( s ) => Some( resolve_loadable( s ).await ), None => None };
+            let indices = match indices_source { Some( s ) => Some( resolve_loadable( s ).await ), None => None };
+
+            gl.bind_vertex_array( Some( &vao ) );
+
+            // Positions (attrib 0)
+            let mut position_buffer = None;
+            if let Some( ref bytes ) = positions
+            {
+              if let Ok( buffer ) = gl::buffer::create( gl )
+              {
+                gl::buffer::upload( gl, &buffer, bytes, gl::STATIC_DRAW );
+                gl.enable_vertex_attrib_array( 0 );
+                gl.vertex_attrib_pointer_with_i32( 0, 2, gl::FLOAT, false, 0, 0 );
+                position_buffer = Some( buffer );
+              }
+            }
+
+            // UVs (attrib 1)
+            let mut uv_buffer = None;
+            if let Some( Some( ref bytes ) ) = uvs
+            {
+              if let Ok( buffer ) = gl::buffer::create( gl )
+              {
+                gl::buffer::upload( gl, &buffer, bytes, gl::STATIC_DRAW );
+                gl.enable_vertex_attrib_array( 1 );
+                gl.vertex_attrib_pointer_with_i32( 1, 2, gl::FLOAT, false, 0, 0 );
+                uv_buffer = Some( buffer );
+              }
+            }
+
+            // Indices
+            let mut index_buffer = None;
+            let mut index_count = None;
+            if let Some( Some( ref bytes ) ) = indices
+            {
+              if let Ok( buffer ) = gl::buffer::create( gl )
+              {
+                gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( &buffer ) );
+                let u8_array = gl::js_sys::Uint8Array::from( bytes.as_slice() );
+                gl.buffer_data_with_array_buffer_view( gl::ELEMENT_ARRAY_BUFFER, &u8_array, gl::STATIC_DRAW );
+                index_count = Some( ( bytes.len() / 2 ) as u32 );
+                index_buffer = Some( buffer );
+              }
+            }
+
+            gl.bind_vertex_array( None );
+
+            let vertex_count = positions.as_ref().map_or( 0, | b | ( b.len() / 8 ) as u32 );
+
+            resources.borrow_mut().store_geometry( id, GpuGeometry
+            {
+              gl : gl.clone(), vao, position_buffer, uv_buffer, index_buffer, vertex_count, index_count,
+            });
+          });
+        }
+        else
+        {
+          // Synchronous path — all data is already in memory.
+          let vao = gl::vao::create( gl ).map_err( map_err )?;
+          gl.bind_vertex_array( Some( &vao ) );
+
+          let mut position_buffer = None;
+          if let crate::assets::Source::Bytes( ref bytes ) = geom.positions
+          {
+            let buffer = gl::buffer::create( gl ).map_err( map_err )?;
+            gl::buffer::upload( gl, &buffer, bytes, gl::STATIC_DRAW );
+            gl.enable_vertex_attrib_array( 0 );
+            gl.vertex_attrib_pointer_with_i32( 0, 2, gl::FLOAT, false, 0, 0 );
+            position_buffer = Some( buffer );
+          }
+
+          let mut uv_buffer = None;
+          if let Some( crate::assets::Source::Bytes( ref bytes ) ) = geom.uvs
+          {
+            let buffer = gl::buffer::create( gl ).map_err( map_err )?;
+            gl::buffer::upload( gl, &buffer, bytes, gl::STATIC_DRAW );
+            gl.enable_vertex_attrib_array( 1 );
+            gl.vertex_attrib_pointer_with_i32( 1, 2, gl::FLOAT, false, 0, 0 );
+            uv_buffer = Some( buffer );
+          }
+
+          let mut index_buffer = None;
+          let mut index_count = None;
+          if let Some( crate::assets::Source::Bytes( ref bytes ) ) = geom.indices
+          {
+            let buffer = gl::buffer::create( gl ).map_err( map_err )?;
+            gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( &buffer ) );
+            let u8_array = js_sys::Uint8Array::from( bytes.as_slice() );
+            gl.buffer_data_with_array_buffer_view( gl::ELEMENT_ARRAY_BUFFER, &u8_array, gl::STATIC_DRAW );
+            index_count = Some( ( bytes.len() / 2 ) as u32 );
+            index_buffer = Some( buffer );
+          }
+
+          gl.bind_vertex_array( None );
+
+          let vertex_count = if let crate::assets::Source::Bytes( ref bytes ) = geom.positions
+          { ( bytes.len() / 8 ) as u32 } else { 0 };
+
+          self.resources.borrow_mut().store_geometry( geom.id, GpuGeometry
+          {
+            gl : gl.clone(), vao, position_buffer, uv_buffer, index_buffer, vertex_count, index_count,
+          });
+        }
+      }
+
+      Ok( () )
+    }
+  }
+
+  // ============================================================================
+  // Backend trait impl
+  // ============================================================================
+
+  impl Backend for WebGlBackend
+  {
+    fn load_assets( &mut self, assets : &Assets ) -> Result< (), RenderError >
+    {
+      self.load_images( &assets.images )?;
+      self.load_sprites( &assets.sprites );
+      self.load_geometries( &assets.geometries )?;
+      // TODO: gradients, patterns, clip masks, fonts
+      Ok( () )
+    }
+
+    fn submit( &mut self, commands : &[ RenderCommand ] ) -> Result< (), RenderError >
+    {
+      let viewport = self.viewport_size();
+
+      for cmd in commands
+      {
+        match cmd
+        {
+          RenderCommand::Clear( c ) => self.cmd_clear( c ),
+
+          // Mesh & sprite
+          RenderCommand::Mesh( m ) => self.cmd_mesh( m, &viewport ),
+          RenderCommand::Sprite( s ) => self.cmd_sprite( s, &viewport ),
+
+          // Batch lifecycle
+          RenderCommand::CreateSpriteBatch( c ) => self.cmd_create_sprite_batch( c ),
+          RenderCommand::CreateMeshBatch( c ) => self.cmd_create_mesh_batch( c ),
+          RenderCommand::BindBatch( b ) => self.cmd_bind_batch( b ),
+          RenderCommand::AddSpriteInstance( si ) => self.cmd_add_sprite_instance( si ),
+          RenderCommand::AddMeshInstance( mi ) => self.cmd_add_mesh_instance( mi ),
+          RenderCommand::SetSpriteInstance( si ) => self.cmd_set_sprite_instance( si ),
+          RenderCommand::SetMeshInstance( mi ) => self.cmd_set_mesh_instance( mi ),
+          RenderCommand::RemoveInstance( ri ) => self.cmd_remove_instance( ri ),
+          RenderCommand::SetSpriteBatchParams( sp ) => self.cmd_set_sprite_batch_params( sp ),
+          RenderCommand::SetMeshBatchParams( mp ) => self.cmd_set_mesh_batch_params( mp ),
+          RenderCommand::UnbindBatch( _ ) => self.cmd_unbind_batch(),
+          RenderCommand::DrawBatch( db ) => self.cmd_draw_batch( db, &viewport ),
+          RenderCommand::DeleteBatch( db ) => self.cmd_delete_batch( db ),
+
+          // Path — skip (TODO)
+          RenderCommand::BeginPath( _ )
+          | RenderCommand::MoveTo( _ )
+          | RenderCommand::LineTo( _ )
+          | RenderCommand::QuadTo( _ )
+          | RenderCommand::CubicTo( _ )
+          | RenderCommand::ArcTo( _ )
+          | RenderCommand::ClosePath( _ )
+          | RenderCommand::EndPath( _ ) => {}
+
+          // Text — skip (TODO)
+          RenderCommand::BeginText( _ )
+          | RenderCommand::Char( _ )
+          | RenderCommand::EndText( _ ) => {}
+
+          // Grouping — skip (TODO)
+          RenderCommand::BeginGroup( _ )
+          | RenderCommand::EndGroup( _ ) => {}
+        }
+      }
+
+      Ok( () )
+    }
+
+    fn output( &self ) -> Result< Output, RenderError >
+    {
+      Ok( Output::Presented )
+    }
+
+    fn resize( &mut self, width : u32, height : u32 )
+    {
+      self.config.width = width;
+      self.config.height = height;
+      self.gl.viewport( 0, 0, width as i32, height as i32 );
+    }
+
+    fn capabilities( &self ) -> Capabilities
+    {
+      Capabilities
+      {
+        paths : true,
+        text : true,
+        meshes : true,
+        sprites : true,
+        batches : true,
+        gradients : true,
+        patterns : true,
+        clip_masks : true,
+        effects : true,
+        blend_modes : true,
+        text_on_path : false,
+        max_texture_size : 8192,
+      }
+    }
+  }
+
+  // ============================================================================
+  // Shared utilities
+  // ============================================================================
+
+  /// Data source that can be sent into a `spawn_local` future.
+  /// Clones the bytes (for `Bytes`) or the path string (for `Path`).
+  enum Loadable
+  {
+    Ready( Vec< u8 > ),
+    Fetch( String ),
+  }
+
+  fn source_to_loadable( source : &crate::assets::Source ) -> Loadable
+  {
+    match source
+    {
+      crate::assets::Source::Bytes( bytes ) => Loadable::Ready( bytes.clone() ),
+      crate::assets::Source::Path( path ) => Loadable::Fetch( path.to_string_lossy().into_owned() ),
+    }
+  }
+
+  async fn resolve_loadable( loadable : Loadable ) -> Option< Vec< u8 > >
+  {
+    match loadable
+    {
+      Loadable::Ready( bytes ) => Some( bytes ),
+      Loadable::Fetch( path ) => gl::file::load( &path ).await.ok(),
+    }
+  }
+
+  /// Like `gl::texture::d2::upload_image_from_path`, but updates
+  /// `GpuTexture.width` / `height` cells once the image loads.
+  fn upload_image_from_path
+  (
+    gl : &gl::GL,
+    src : &str,
+    id : ResourceId< asset::Image >,
+    resources : &Rc< RefCell< GpuResources > >,
+  ) -> web_sys::WebGlTexture
+  {
+    let document = web_sys::window().expect( "no window" ).document().expect( "no document" );
+
+    let texture = gl.create_texture().expect( "failed to create texture" );
+
+    let img : HtmlImageElement = document.create_element( "img" )
+      .expect( "can't create img" )
+      .dyn_into()
+      .expect( "not an HtmlImageElement" );
+    img.style().set_property( "display", "none" ).expect( "can't hide img" );
+
+    let on_load : Closure< dyn Fn() > = Closure::new(
+    {
+      let gl = gl.clone();
+      let img = img.clone();
+      let texture = texture.clone();
+      let resources = Rc::clone( resources );
+      move ||
+      {
+        gl::texture::d2::upload( &gl, Some( &texture ), &img );
+
+        if let Some( gpu_tex ) = resources.borrow().texture( id )
+        {
+          gpu_tex.width.set( img.natural_width() );
+          gpu_tex.height.set( img.natural_height() );
+        }
+
+        img.remove();
+      }
+    });
+
+    img.set_onload( Some( on_load.as_ref().unchecked_ref() ) );
+    img.set_src( src );
+    on_load.forget();
+
+    texture
+  }
+
+  fn apply_texture_filter( gl : &gl::GL, filter : &SamplerFilter )
+  {
+    match filter
+    {
+      SamplerFilter::Nearest => gl::texture::d2::filter_nearest( gl ),
+      SamplerFilter::Linear => gl::texture::d2::filter_linear( gl ),
+    };
+  }
+
+  fn topology_to_gl( t : &Topology ) -> u32
+  {
+    match t
+    {
+      Topology::TriangleList => gl::TRIANGLES,
+      Topology::TriangleStrip => gl::TRIANGLE_STRIP,
+      Topology::LineList => gl::LINES,
+      Topology::LineStrip => gl::LINE_STRIP,
+    }
+  }
+}
+
+mod_interface::mod_interface!
+{
+  own use ArrayBuffer;
+  own use WebGlBackend;
+}

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1353,6 +1353,13 @@ mod private
       // Bump the generation counter so any in-flight `spawn_local` futures from
       // a previous cycle notice they are stale and bail out before overwriting
       // entries belonging to this new cycle.
+      //
+      // ORDER MATTERS: batches must be cleared BEFORE geometries / textures (which
+      // are cleared inside `load_images` / `load_geometries` below). A mesh batch's
+      // VAO holds attrib pointers into the geometry's position / uv / index buffers;
+      // if the geometry was dropped first, those buffers would be deleted while
+      // still referenced by live batch VAOs. Dropping batches first ensures each
+      // batch VAO is gone before any buffer it referenced is freed.
       {
         let mut res = self.resources.borrow_mut();
         res.generation = res.generation.wrapping_add( 1 );

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -695,7 +695,12 @@ mod private
       // Initial GL state
       gl.viewport( 0, 0, config.width as i32, config.height as i32 );
       gl.enable( gl::BLEND );
-      gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA );
+      // Use separate factors for the alpha channel so the framebuffer alpha follows
+      // the Porter-Duff "over" rule: a = src_a + dst_a * (1 - src_a). Using the same
+      // SRC_ALPHA factor on alpha would yield src_a^2 + dst_a*(1-src_a), corrupting
+      // alpha when the canvas is composited against a transparent page or read via
+      // readPixels.
+      gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA );
 
       // Query the actual hardware limit; fall back to the WebGL2 guaranteed minimum.
       // get_parameter returns a JsValue; as_f64() is the idiomatic way to extract it.
@@ -729,18 +734,27 @@ mod private
     fn apply_blend( &self, blend : &BlendMode )
     {
       let gl = &self.gl;
+      // Alpha factors are always (ONE, ONE_MINUS_SRC_ALPHA) so the framebuffer alpha
+      // follows Porter-Duff "over": a = src_a + dst_a * (1 - src_a). Using the RGB
+      // factors on the alpha channel would produce wrong framebuffer alpha (e.g.
+      // src_a^2 under Normal) and break readPixels / compositing onto a transparent
+      // canvas background.
       match blend
       {
-        BlendMode::Add => gl.blend_func( gl::SRC_ALPHA, gl::ONE ),
+        // Color: src + dst. Alpha: standard over.
+        BlendMode::Add => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
         // Approximation: equals src*dst only when src_alpha=1.
         // TODO(FBO): replace with Photoshop-accurate formula — see BlendMode::Multiply doc.
-        BlendMode::Multiply => gl.blend_func( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA ),
-        BlendMode::Screen => gl.blend_func( gl::ONE, gl::ONE_MINUS_SRC_COLOR ),
+        // Color: src*dst + dst*(1-src_a). Alpha: standard over.
+        BlendMode::Multiply => gl.blend_func_separate( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
+        // Color: src + dst*(1-src). Alpha: standard over.
+        BlendMode::Screen => gl.blend_func_separate( gl::ONE, gl::ONE_MINUS_SRC_COLOR, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
         // TODO: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
         // expressed as a single blend_func call — it requires a custom shader or a
         // separate FBO read-back pass, neither of which is implemented yet.
         // Overlay falls back to Normal so rendering is at least visible.
-        BlendMode::Normal | BlendMode::Overlay => gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA ),
+        // Color: src*src_a + dst*(1-src_a). Alpha: standard over.
+        BlendMode::Normal | BlendMode::Overlay => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
       }
     }
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -67,7 +67,7 @@ mod private
     }
 
     /// Draw a single sprite as a textured quad (triangle strip, 4 vertices from `gl_VertexID`).
-    fn draw( &self, gl : &gl::GL, transform : &[ f32; 9 ], uv_rect : &[ f32; 4 ], sprite_size : &[ f32; 2 ], tint : &[ f32; 4 ], viewport : &[ f32; 2 ], depth : f32 )
+    fn draw( &self, gl : &gl::GL, transform : &[ f32; 9 ], uv_rect : &[ f32; 4 ], sprite_size : &[ f32; 2 ], tint : &[ f32; 4 ], viewport : &[ f32; 2 ], depth : f32, max_depth : f32 )
     {
       // Unbind any VAO to prevent stale attribute state from interfering
       gl.bind_vertex_array( None );
@@ -78,11 +78,12 @@ mod private
       self.program.uniform_upload( "u_tint", tint );
       self.program.uniform_upload( "u_viewport", viewport );
       self.program.uniform_upload( "u_depth", &depth );
+      self.program.uniform_upload( "u_max_depth", &max_depth );
       gl.draw_arrays( gl::TRIANGLE_STRIP, 0, 4 );
     }
 
     /// Draw an instanced sprite batch.
-    fn draw_batch( &self, gl : &gl::GL, batch : &GpuBatch, resources : &GpuResources, viewport : &[ f32; 2 ] )
+    fn draw_batch( &self, gl : &gl::GL, batch : &GpuBatch, resources : &GpuResources, viewport : &[ f32; 2 ], max_depth : f32 )
     {
       let GpuBatch::Sprite { instances, vao, params, .. } = batch else { return; };
       if instances.is_empty() { return; }
@@ -101,6 +102,7 @@ mod private
       let parent_mat = params.transform.to_mat3();
       self.batch_program.uniform_matrix_upload( "u_parent", &parent_mat, true );
       self.batch_program.uniform_upload( "u_parent_depth", &params.transform.depth );
+      self.batch_program.uniform_upload( "u_max_depth", &max_depth );
 
       gl.bind_vertex_array( Some( vao ) );
       gl.draw_arrays_instanced( gl::TRIANGLE_STRIP, 0, 4, instances.len() as i32 );
@@ -154,6 +156,7 @@ mod private
       viewport : &[ f32; 2 ],
       use_texture : bool,
       depth : f32,
+      max_depth : f32,
     )
     {
       self.program.activate();
@@ -162,6 +165,7 @@ mod private
       self.program.uniform_upload( "u_viewport", viewport );
       self.program.uniform_upload( "u_use_texture", &i32::from( use_texture ) );
       self.program.uniform_upload( "u_depth", &depth );
+      self.program.uniform_upload( "u_max_depth", &max_depth );
 
       gl.bind_vertex_array( Some( &geom.vao ) );
 
@@ -180,7 +184,7 @@ mod private
     }
 
     /// Draw an instanced mesh batch. VAO is already configured via `setup_mesh_batch_vao`.
-    fn draw_batch( &self, gl : &gl::GL, batch : &GpuBatch, resources : &GpuResources, viewport : &[ f32; 2 ] )
+    fn draw_batch( &self, gl : &gl::GL, batch : &GpuBatch, resources : &GpuResources, viewport : &[ f32; 2 ], max_depth : f32 )
     {
       let GpuBatch::Mesh { instances, vao, params, .. } = batch else { return };
       if instances.is_empty() { return; }
@@ -205,6 +209,7 @@ mod private
       let parent_mat = params.transform.to_mat3();
       self.batch_program.uniform_matrix_upload( "u_parent", &parent_mat, true );
       self.batch_program.uniform_upload( "u_parent_depth", &params.transform.depth );
+      self.batch_program.uniform_upload( "u_max_depth", &max_depth );
 
       gl.bind_vertex_array( Some( vao ) );
 
@@ -364,7 +369,7 @@ mod private
           use_texture = true;
         }
 
-        self.mesh.draw( &self.gl, geom, &mat, &color, topology_to_gl( &m.topology ), viewport, use_texture, m.transform.depth );
+        self.mesh.draw( &self.gl, geom, &mat, &color, topology_to_gl( &m.topology ), viewport, use_texture, m.transform.depth, self.config.max_depth );
       }
     }
 
@@ -389,7 +394,7 @@ mod private
 
       let mat = s.transform.to_mat3();
       apply_blend( &self.gl, &s.blend );
-      self.sprite.draw( &self.gl, &mat, &uv_rect, &sprite_size, &s.tint, viewport, s.transform.depth );
+      self.sprite.draw( &self.gl, &mat, &uv_rect, &sprite_size, &s.tint, viewport, s.transform.depth, self.config.max_depth );
     }
 
     fn cmd_create_sprite_batch( &mut self, cmd : &CreateSpriteBatch ) -> Result< (), RenderError >
@@ -735,8 +740,8 @@ mod private
       });
       match gpu_batch
       {
-        GpuBatch::Sprite { .. } => self.sprite.draw_batch( &self.gl, gpu_batch, &res, viewport ),
-        GpuBatch::Mesh { .. } => self.mesh.draw_batch( &self.gl, gpu_batch, &res, viewport ),
+        GpuBatch::Sprite { .. } => self.sprite.draw_batch( &self.gl, gpu_batch, &res, viewport, self.config.max_depth ),
+        GpuBatch::Mesh { .. } => self.mesh.draw_batch( &self.gl, gpu_batch, &res, viewport, self.config.max_depth ),
       }
       Ok( () )
     }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -478,13 +478,13 @@ mod private
           instances.push( &data ).map_err( | e | RenderError::BackendError( e.to_string() ) )?,
         Some( GpuBatch::Mesh { .. } ) => return Err( RenderError::BackendError
         (
-          format!( "AddSpriteInstance: batch {:?} is a Mesh batch; sprite instances require a Sprite batch", batch_id )
+          format!( "AddSpriteInstance: batch {batch_id:?} is a Mesh batch; sprite instances require a Sprite batch" )
         )),
         None =>
         {
           web_sys::console::warn_1
           (
-            &format!( "AddSpriteInstance: batch {:?} not found (dropped)", batch_id ).into()
+            &format!( "AddSpriteInstance: batch {batch_id:?} not found (dropped)" ).into()
           );
         }
       }
@@ -502,13 +502,13 @@ mod private
           instances.push( &data ).map_err( | e | RenderError::BackendError( e.to_string() ) )?,
         Some( GpuBatch::Sprite { .. } ) => return Err( RenderError::BackendError
         (
-          format!( "AddMeshInstance: batch {:?} is a Sprite batch; mesh instances require a Mesh batch", batch_id )
+          format!( "AddMeshInstance: batch {batch_id:?} is a Sprite batch; mesh instances require a Mesh batch" )
         )),
         None =>
         {
           web_sys::console::warn_1
           (
-            &format!( "AddMeshInstance: batch {:?} not found (dropped)", batch_id ).into()
+            &format!( "AddMeshInstance: batch {batch_id:?} not found (dropped)" ).into()
           );
         }
       }
@@ -550,13 +550,13 @@ mod private
         }
         Some( GpuBatch::Mesh { .. } ) => return Err( RenderError::BackendError
         (
-          format!( "SetSpriteInstance: batch {:?} is a Mesh batch; sprite instances require a Sprite batch", batch_id )
+          format!( "SetSpriteInstance: batch {batch_id:?} is a Mesh batch; sprite instances require a Sprite batch" )
         )),
         None =>
         {
           web_sys::console::warn_1
           (
-            &format!( "SetSpriteInstance: batch {:?} not found (dropped)", batch_id ).into()
+            &format!( "SetSpriteInstance: batch {batch_id:?} not found (dropped)" ).into()
           );
         }
       }
@@ -583,13 +583,13 @@ mod private
         }
         Some( GpuBatch::Sprite { .. } ) => return Err( RenderError::BackendError
         (
-          format!( "SetMeshInstance: batch {:?} is a Sprite batch; mesh instances require a Mesh batch", batch_id )
+          format!( "SetMeshInstance: batch {batch_id:?} is a Sprite batch; mesh instances require a Mesh batch" )
         )),
         None =>
         {
           web_sys::console::warn_1
           (
-            &format!( "SetMeshInstance: batch {:?} not found (dropped)", batch_id ).into()
+            &format!( "SetMeshInstance: batch {batch_id:?} not found (dropped)" ).into()
           );
         }
       }
@@ -605,7 +605,7 @@ mod private
       {
         web_sys::console::warn_1
         (
-          &format!( "RemoveInstance: batch {:?} not found (dropped)", batch_id ).into()
+          &format!( "RemoveInstance: batch {batch_id:?} not found (dropped)" ).into()
         );
         return Ok( () );
       };
@@ -641,13 +641,13 @@ mod private
         Some( GpuBatch::Sprite { params, .. } ) => { *params = cmd.params; }
         Some( GpuBatch::Mesh { .. } ) => return Err( RenderError::BackendError
         (
-          format!( "SetSpriteBatchParams: batch {:?} is a Mesh batch", batch_id )
+          format!( "SetSpriteBatchParams: batch {batch_id:?} is a Mesh batch" )
         )),
         None =>
         {
           web_sys::console::warn_1
           (
-            &format!( "SetSpriteBatchParams: batch {:?} not found (dropped)", batch_id ).into()
+            &format!( "SetSpriteBatchParams: batch {batch_id:?} not found (dropped)" ).into()
           );
         }
       }
@@ -663,13 +663,13 @@ mod private
         Some( GpuBatch::Mesh { params, .. } ) => { *params = cmd.params; }
         Some( GpuBatch::Sprite { .. } ) => return Err( RenderError::BackendError
         (
-          format!( "SetMeshBatchParams: batch {:?} is a Sprite batch", batch_id )
+          format!( "SetMeshBatchParams: batch {batch_id:?} is a Sprite batch" )
         )),
         None =>
         {
           web_sys::console::warn_1
           (
-            &format!( "SetMeshBatchParams: batch {:?} not found (dropped)", batch_id ).into()
+            &format!( "SetMeshBatchParams: batch {batch_id:?} not found (dropped)" ).into()
           );
         }
       }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1303,6 +1303,9 @@ mod private
       // GpuBatch::drop calls delete_vertex_array; ArrayBuffer::drop calls delete_buffer.
       // Safe to call multiple times (e.g. level transitions).
       self.resources.borrow_mut().batches.clear();
+      // Clear the stale recording batch ID: the referenced batch no longer exists,
+      // so leaving it set would make cmd_bind_batch reject any new bind on the next frame.
+      self.recording_batch = None;
       self.load_images( &assets.images )?;
       self.load_sprites( &assets.sprites );
       self.load_geometries( &assets.geometries )?;

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1065,6 +1065,26 @@ mod private
             {
               gl : gl.clone(), vao, position_buffer, uv_buffer, index_buffer, vertex_count, index_count,
             });
+
+            // Re-setup any mesh batch VAOs that reference this geometry.
+            // Batches created before async load completed only have instance attribs;
+            // now that geometry buffers are available, add geometry attribs too.
+            {
+              let res = resources.borrow();
+              if let Some( geom ) = res.geometry( id )
+              {
+                for batch in res.batches.values()
+                {
+                  if let GpuBatch::Mesh { vao, params, instances, .. } = batch
+                  {
+                    if params.geometry == id
+                    {
+                      setup_mesh_batch_vao( gl, vao, geom, instances.buffer() );
+                    }
+                  }
+                }
+              }
+            }
           });
         }
         else

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -763,11 +763,11 @@ mod private
       self.recording_batch = Some( cmd.batch );
     }
 
-    fn cmd_add_sprite_instance( &mut self, si : &AddSpriteInstance )
+    fn cmd_add_sprite_instance( &mut self, si : &AddSpriteInstance ) -> Result< (), RenderError >
     {
-      let Some( batch_id ) = self.recording_batch else { return };
+      let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let mut res = self.resources.borrow_mut();
-      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region ) else { return };
+      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region ) else { return Ok( () ) };
       let data = SpriteInstanceData
       {
         transform : si.transform.to_mat3(),
@@ -776,19 +776,21 @@ mod private
       };
       if let Some( GpuBatch::Sprite { instances, .. } ) = res.batch_mut( batch_id )
       {
-        let _ = instances.push( &data );
+        instances.push( &data ).map_err( | e | RenderError::BackendError( e.to_string() ) )?;
       }
+      Ok( () )
     }
 
-    fn cmd_add_mesh_instance( &mut self, mi : &AddMeshInstance )
+    fn cmd_add_mesh_instance( &mut self, mi : &AddMeshInstance ) -> Result< (), RenderError >
     {
-      let Some( batch_id ) = self.recording_batch else { return };
+      let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let data = MeshInstanceData { transform : mi.transform.to_mat3() };
       let mut res = self.resources.borrow_mut();
       if let Some( GpuBatch::Mesh { instances, .. } ) = res.batch_mut( batch_id )
       {
-        let _ = instances.push( &data );
+        instances.push( &data ).map_err( | e | RenderError::BackendError( e.to_string() ) )?;
       }
+      Ok( () )
     }
 
     fn cmd_set_sprite_instance( &mut self, si : &SetSpriteInstance )
@@ -1178,8 +1180,8 @@ mod private
           RenderCommand::CreateSpriteBatch( c ) => self.cmd_create_sprite_batch( c ),
           RenderCommand::CreateMeshBatch( c ) => self.cmd_create_mesh_batch( c ),
           RenderCommand::BindBatch( b ) => self.cmd_bind_batch( b ),
-          RenderCommand::AddSpriteInstance( si ) => self.cmd_add_sprite_instance( si ),
-          RenderCommand::AddMeshInstance( mi ) => self.cmd_add_mesh_instance( mi ),
+          RenderCommand::AddSpriteInstance( si ) => self.cmd_add_sprite_instance( si )?,
+          RenderCommand::AddMeshInstance( mi ) => self.cmd_add_mesh_instance( mi )?,
           RenderCommand::SetSpriteInstance( si ) => self.cmd_set_sprite_instance( si ),
           RenderCommand::SetMeshInstance( mi ) => self.cmd_set_mesh_instance( mi ),
           RenderCommand::RemoveInstance( ri ) => self.cmd_remove_instance( ri ),

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -758,9 +758,17 @@ mod private
       });
     }
 
-    fn cmd_bind_batch( &mut self, cmd : &BindBatch )
+    fn cmd_bind_batch( &mut self, cmd : &BindBatch ) -> Result< (), RenderError >
     {
+      if let Some( current ) = self.recording_batch
+      {
+        return Err( RenderError::BackendError
+        (
+          format!( "BindBatch({:?}): batch {:?} is already bound; call UnbindBatch first", cmd.batch, current )
+        ));
+      }
       self.recording_batch = Some( cmd.batch );
+      Ok( () )
     }
 
     fn cmd_add_sprite_instance( &mut self, si : &AddSpriteInstance ) -> Result< (), RenderError >
@@ -880,8 +888,15 @@ mod private
       }
     }
 
-    fn cmd_draw_batch( &self, db : &DrawBatch, viewport : &[ f32; 2 ] )
+    fn cmd_draw_batch( &self, db : &DrawBatch, viewport : &[ f32; 2 ] ) -> Result< (), RenderError >
     {
+      if self.recording_batch == Some( db.batch )
+      {
+        return Err( RenderError::BackendError
+        (
+          format!( "DrawBatch({:?}): batch is still bound; call UnbindBatch before drawing", db.batch )
+        ));
+      }
       let res = self.resources.borrow();
       if let Some( gpu_batch ) = res.batch( db.batch )
       {
@@ -896,11 +911,18 @@ mod private
           GpuBatch::Mesh { .. } => self.mesh.draw_batch( &self.gl, gpu_batch, &res, viewport ),
         }
       }
+      Ok( () )
     }
 
     fn cmd_delete_batch( &mut self, db : &DeleteBatch )
     {
-      // ArrayBuffer::drop handles GPU buffer cleanup
+      // If the batch being deleted is currently bound, clear the recording slot so
+      // subsequent instance commands do not silently target a dangling id.
+      if self.recording_batch == Some( db.batch )
+      {
+        self.recording_batch = None;
+      }
+      // ArrayBuffer::drop handles GPU buffer cleanup.
       self.resources.borrow_mut().batches.remove( &db.batch );
     }
 
@@ -1179,7 +1201,7 @@ mod private
           // Batch lifecycle
           RenderCommand::CreateSpriteBatch( c ) => self.cmd_create_sprite_batch( c ),
           RenderCommand::CreateMeshBatch( c ) => self.cmd_create_mesh_batch( c ),
-          RenderCommand::BindBatch( b ) => self.cmd_bind_batch( b ),
+          RenderCommand::BindBatch( b ) => self.cmd_bind_batch( b )?,
           RenderCommand::AddSpriteInstance( si ) => self.cmd_add_sprite_instance( si )?,
           RenderCommand::AddMeshInstance( mi ) => self.cmd_add_mesh_instance( mi )?,
           RenderCommand::SetSpriteInstance( si ) => self.cmd_set_sprite_instance( si ),
@@ -1188,7 +1210,7 @@ mod private
           RenderCommand::SetSpriteBatchParams( sp ) => self.cmd_set_sprite_batch_params( sp ),
           RenderCommand::SetMeshBatchParams( mp ) => self.cmd_set_mesh_batch_params( mp ),
           RenderCommand::UnbindBatch( _ ) => self.cmd_unbind_batch(),
-          RenderCommand::DrawBatch( db ) => self.cmd_draw_batch( db, &viewport ),
+          RenderCommand::DrawBatch( db ) => self.cmd_draw_batch( db, &viewport )?,
           RenderCommand::DeleteBatch( db ) => self.cmd_delete_batch( db ),
 
           // Path — skip (TODO)

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -46,13 +46,17 @@ mod private
     /// Creates a new GPU array buffer with the given initial capacity (in elements).
     ///
     /// # Errors
-    /// Returns `WebglError` if the underlying GPU buffer cannot be created.
+    /// Returns `WebglError` if the underlying GPU buffer cannot be created or if
+    /// `capacity * stride` overflows `i32` (WebGL buffer size limit).
     pub fn new( gl : &gl::GL, capacity : u32 ) -> Result< Self, gl::WebglError >
     {
       let buffer = gl::buffer::create( gl )?;
-      let byte_size = capacity * Self::stride();
+      let byte_size = capacity
+        .checked_mul( Self::stride() )
+        .and_then( | n | i32::try_from( n ).ok() )
+        .ok_or( gl::WebglError::FailedToAllocateResource( "Buffer" ) )?;
       gl.bind_buffer( gl::ARRAY_BUFFER, Some( &buffer ) );
-      gl.buffer_data_with_i32( gl::ARRAY_BUFFER, byte_size as i32, gl::DYNAMIC_DRAW );
+      gl.buffer_data_with_i32( gl::ARRAY_BUFFER, byte_size, gl::DYNAMIC_DRAW );
       gl.bind_buffer( gl::ARRAY_BUFFER, None );
 
       let scratch = gl::buffer::create( gl )?;
@@ -164,12 +168,16 @@ mod private
     /// Doubles the capacity, copying old data GPU-to-GPU.
     fn grow( &mut self ) -> Result< (), gl::WebglError >
     {
-      let new_capacity = if self.capacity == 0 { 4 } else { self.capacity * 2 };
-      let new_byte_size = new_capacity * Self::stride();
+      // saturating_mul avoids wrapping; the byte_size check below catches any overflow.
+      let new_capacity = self.capacity.saturating_mul( 2 ).max( 4 );
+      let new_byte_size = new_capacity
+        .checked_mul( Self::stride() )
+        .and_then( | n | i32::try_from( n ).ok() )
+        .ok_or( gl::WebglError::FailedToAllocateResource( "Buffer" ) )?;
 
       let new_buffer = gl::buffer::create( &self.gl )?;
       self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &new_buffer ) );
-      self.gl.buffer_data_with_i32( gl::ARRAY_BUFFER, new_byte_size as i32, gl::DYNAMIC_DRAW );
+      self.gl.buffer_data_with_i32( gl::ARRAY_BUFFER, new_byte_size, gl::DYNAMIC_DRAW );
       self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
 
       if self.len > 0

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -273,7 +273,9 @@ mod private
     uv_buffer : Option< web_sys::WebGlBuffer >,
     index_buffer : Option< web_sys::WebGlBuffer >,
     vertex_count : u32,
-    index_count : Option< u32 >,
+    /// Number of indices and the GL type constant (`UNSIGNED_BYTE` / `UNSIGNED_SHORT` / `UNSIGNED_INT`).
+    /// `None` if the geometry has no index buffer (draw with `drawArrays`).
+    index_count : Option< ( u32, u32 ) >,
   }
 
   impl Drop for GpuGeometry
@@ -537,9 +539,9 @@ mod private
 
       gl.bind_vertex_array( Some( &geom.vao ) );
 
-      if let Some( count ) = geom.index_count
+      if let Some( ( count, gl_type ) ) = geom.index_count
       {
-        gl.draw_elements_with_i32( topology, count as i32, gl::UNSIGNED_SHORT, 0 );
+        gl.draw_elements_with_i32( topology, count as i32, gl_type, 0 );
       }
       else
       {
@@ -577,9 +579,9 @@ mod private
 
       gl.bind_vertex_array( Some( vao ) );
 
-      if let Some( count ) = geom.index_count
+      if let Some( ( count, gl_type ) ) = geom.index_count
       {
-        gl.draw_elements_instanced_with_i32( topology, count as i32, gl::UNSIGNED_SHORT, 0, instances.len() as i32 );
+        gl.draw_elements_instanced_with_i32( topology, count as i32, gl_type, 0, instances.len() as i32 );
       }
       else
       {
@@ -1047,6 +1049,17 @@ mod private
 
       for geom in geometries
       {
+        // Validate index format early so both sync and async paths can use it.
+        // geom.indices == None is fine (non-indexed draw); geom.data_type only matters when indices are present.
+        let ( idx_stride, idx_gl_type ) = if geom.indices.is_some()
+        {
+          index_format( &geom.data_type )?
+        }
+        else
+        {
+          ( 0, 0 ) // unused when there are no indices
+        };
+
         let has_path =
           matches!( geom.positions, crate::assets::Source::Path( _ ) )
           || matches!( geom.uvs, Some( crate::assets::Source::Path( _ ) ) )
@@ -1117,7 +1130,7 @@ mod private
                 gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( &buffer ) );
                 let u8_array = gl::js_sys::Uint8Array::from( bytes.as_slice() );
                 gl.buffer_data_with_array_buffer_view( gl::ELEMENT_ARRAY_BUFFER, &u8_array, gl::STATIC_DRAW );
-                index_count = Some( ( bytes.len() / 2 ) as u32 );
+                index_count = Some( ( ( bytes.len() as u32 ) / idx_stride, idx_gl_type ) );
                 index_buffer = Some( buffer );
               }
             }
@@ -1186,7 +1199,7 @@ mod private
             gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( &buffer ) );
             let u8_array = js_sys::Uint8Array::from( bytes.as_slice() );
             gl.buffer_data_with_array_buffer_view( gl::ELEMENT_ARRAY_BUFFER, &u8_array, gl::STATIC_DRAW );
-            index_count = Some( ( bytes.len() / 2 ) as u32 );
+            index_count = Some( ( ( bytes.len() as u32 ) / idx_stride, idx_gl_type ) );
             index_buffer = Some( buffer );
           }
 
@@ -1392,6 +1405,24 @@ mod private
     on_error.forget();
 
     texture
+  }
+
+  /// Maps a `DataType` to `(bytes_per_index, gl_type_constant)` for `drawElements`.
+  ///
+  /// Returns `Err` for `F32`, which is not a valid WebGL index type.
+  fn index_format( dt : &crate::assets::DataType ) -> Result< ( u32, u32 ), RenderError >
+  {
+    use crate::assets::DataType;
+    match dt
+    {
+      DataType::U8  => Ok( ( 1, gl::UNSIGNED_BYTE ) ),
+      DataType::U16 => Ok( ( 2, gl::UNSIGNED_SHORT ) ),
+      DataType::U32 => Ok( ( 4, gl::UNSIGNED_INT ) ),
+      DataType::F32 => Err( RenderError::BackendError
+      (
+        "GeometryAsset.data_type: F32 is not a valid index format; use U8, U16, or U32".into()
+      )),
+    }
   }
 
   fn apply_texture_filter( gl : &gl::GL, filter : &SamplerFilter )

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1088,19 +1088,62 @@ mod private
 
             gl.bind_texture( gl::TEXTURE_2D, Some( &tex ) );
 
-            let gl_fmt = match format
+            // Pick a WebGL2 format + upload bytes. Gray8 and GrayAlpha8 are
+            // expanded to RGBA8 on the CPU before upload because:
+            //
+            //   1. WebGL1's LUMINANCE / LUMINANCE_ALPHA replicated the stored
+            //      channels across RGB on sample. On WebGL2 they are legacy
+            //      unsized formats backed by R8 / RG8 and sample as
+            //      (L, 0, 0, 1) / (L, 0, 0, A) — grayscale images render red.
+            //
+            //   2. The obvious native GL ES 3.0 fix — R8 / RG8 + TEXTURE_SWIZZLE_*
+            //      — is explicitly *removed* from WebGL2 (spec §6.19):
+            //      TEXTURE_SWIZZLE_R/G/B/A are not valid `texParameteri` names
+            //      and produce INVALID_ENUM.
+            //
+            // CPU expansion costs 4× memory for Gray8 / 2× for GrayAlpha8 at
+            // upload time, which is acceptable for the grayscale images typical
+            // in tilemap content (masks, icons, height fields) and is portable
+            // across WebGL2 implementations without special GL state.
+            let ( gl_fmt, unpack_alignment, bytes_owned ) : ( u32, i32, Option< Vec< u8 > > ) = match format
             {
-              crate::assets::PixelFormat::Rgba8 => gl::RGBA,
-              crate::assets::PixelFormat::Rgb8 => gl::RGB,
-              crate::assets::PixelFormat::Gray8 => gl::LUMINANCE,
-              crate::assets::PixelFormat::GrayAlpha8 => gl::LUMINANCE_ALPHA,
+              crate::assets::PixelFormat::Rgba8 => ( gl::RGBA, 4, None ),
+              // RGB rows are 3*width bytes — may not be 4-aligned, so relax the
+              // UNPACK stride to match. Restored below.
+              crate::assets::PixelFormat::Rgb8  => ( gl::RGB, 1, None ),
+              crate::assets::PixelFormat::Gray8 =>
+              {
+                let mut rgba = Vec::with_capacity( bytes.len() * 4 );
+                for &l in bytes
+                {
+                  rgba.extend_from_slice( &[ l, l, l, 0xFF ] );
+                }
+                ( gl::RGBA, 4, Some( rgba ) )
+              }
+              crate::assets::PixelFormat::GrayAlpha8 =>
+              {
+                let mut rgba = Vec::with_capacity( bytes.len() * 2 );
+                for pair in bytes.chunks_exact( 2 )
+                {
+                  let ( l, a ) = ( pair[ 0 ], pair[ 1 ] );
+                  rgba.extend_from_slice( &[ l, l, l, a ] );
+                }
+                ( gl::RGBA, 4, Some( rgba ) )
+              }
             };
+
+            // Relax UNPACK_ALIGNMENT only when the per-row byte count may not be
+            // a multiple of 4 (RGB8 at odd widths). Default 4 is correct for
+            // RGBA8 and for the CPU-expanded grayscale paths above.
+            if unpack_alignment != 4 { gl.pixel_storei( gl::UNPACK_ALIGNMENT, unpack_alignment ); }
+
+            let upload_bytes : &[ u8 ] = bytes_owned.as_deref().unwrap_or( bytes );
 
             gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array
             (
               gl::TEXTURE_2D, 0, gl_fmt as i32,
               *width as i32, *height as i32, 0,
-              gl_fmt, gl::UNSIGNED_BYTE, Some( bytes ),
+              gl_fmt, gl::UNSIGNED_BYTE, Some( upload_bytes ),
             )
             .map_err( | e | RenderError::BackendError
             (
@@ -1110,6 +1153,9 @@ mod private
                 img.id, e
               )
             ))?;
+
+            // Restore default so later uploads aren't surprised by residual state.
+            if unpack_alignment != 4 { gl.pixel_storei( gl::UNPACK_ALIGNMENT, 4 ); }
 
             ( tex, *width, *height )
           }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -379,16 +379,30 @@ mod private
   {
     Sprite
     {
+      gl : gl::GL,
       instances : ArrayBuffer< SpriteInstanceData >,
       vao : web_sys::WebGlVertexArrayObject,
       params : SpriteBatchParams,
     },
     Mesh
     {
+      gl : gl::GL,
       instances : ArrayBuffer< MeshInstanceData >,
       vao : web_sys::WebGlVertexArrayObject,
       params : MeshBatchParams,
     },
+  }
+
+  impl Drop for GpuBatch
+  {
+    fn drop( &mut self )
+    {
+      match self
+      {
+        Self::Sprite { gl, vao, .. } | Self::Mesh { gl, vao, .. } =>
+          gl.delete_vertex_array( Some( vao ) ),
+      }
+    }
   }
 
   /// Binds instance attrib pointers for a sprite batch VAO.
@@ -513,7 +527,7 @@ mod private
     /// Draw an instanced sprite batch.
     fn draw_batch( &self, gl : &gl::GL, batch : &GpuBatch, resources : &GpuResources, viewport : &[ f32; 2 ] )
     {
-      let GpuBatch::Sprite { instances, vao, params } = batch else { return; };
+      let GpuBatch::Sprite { instances, vao, params, .. } = batch else { return; };
       if instances.is_empty() { return; }
 
       let Some( gpu_tex ) = resources.texture( params.sheet ) else { return; };
@@ -599,7 +613,7 @@ mod private
     /// Draw an instanced mesh batch. VAO is already configured via `setup_mesh_batch_vao`.
     fn draw_batch( &self, gl : &gl::GL, batch : &GpuBatch, resources : &GpuResources, viewport : &[ f32; 2 ] )
     {
-      let GpuBatch::Mesh { instances, vao, params } = batch else { return };
+      let GpuBatch::Mesh { instances, vao, params, .. } = batch else { return };
       if instances.is_empty() { return; }
 
       let Some( geom ) = resources.geometry( params.geometry ) else { return };
@@ -794,6 +808,7 @@ mod private
       setup_sprite_batch_vao( gl, &vao, instances.buffer() );
       self.resources.borrow_mut().store_batch( cmd.batch, GpuBatch::Sprite
       {
+        gl : self.gl.clone(),
         instances,
         vao,
         params : cmd.params,
@@ -815,6 +830,7 @@ mod private
       drop( res );
       self.resources.borrow_mut().store_batch( cmd.batch, GpuBatch::Mesh
       {
+        gl : self.gl.clone(),
         instances,
         vao,
         params : cmd.params,
@@ -969,7 +985,7 @@ mod private
             {
               setup_sprite_batch_vao( &self.gl, vao, instances.buffer() );
             }
-            GpuBatch::Mesh { instances, vao, params } =>
+            GpuBatch::Mesh { instances, vao, params, .. } =>
             {
               if let Some( geom ) = res.geometry( params.geometry )
               {
@@ -1281,6 +1297,10 @@ mod private
   {
     fn load_assets( &mut self, assets : &Assets ) -> Result< (), RenderError >
     {
+      // Reset all GPU state: textures, sprites, geometries, and batches.
+      // GpuBatch::drop calls delete_vertex_array; ArrayBuffer::drop calls delete_buffer.
+      // Safe to call multiple times (e.g. level transitions).
+      self.resources.borrow_mut().batches.clear();
       self.load_images( &assets.images )?;
       self.load_sprites( &assets.sprites );
       self.load_geometries( &assets.geometries )?;

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -45,8 +45,11 @@ mod private
   {
     /// Creates a new GPU array buffer with the given initial capacity (in elements).
     ///
+    /// Allocates two GPU buffers: the main data buffer (`capacity * stride` bytes)
+    /// and a one-element scratch buffer (`stride` bytes) used by `swap_remove`.
+    ///
     /// # Errors
-    /// Returns `WebglError` if the underlying GPU buffer cannot be created or if
+    /// Returns `WebglError` if any GPU buffer cannot be created, or if
     /// `capacity * stride` overflows `i32` (WebGL buffer size limit).
     pub fn new( gl : &gl::GL, capacity : u32 ) -> Result< Self, gl::WebglError >
     {
@@ -1101,6 +1104,9 @@ mod private
       Ok( () )
     }
 
+    // Returns () unlike load_images/load_geometries because sprite loading is
+    // infallible — it only stores sub-regions of already-loaded textures (no GPU
+    // upload, no allocation that can fail).
     fn load_sprites( &mut self, sprites : &[ crate::assets::SpriteAsset ] )
     {
       self.resources.borrow_mut().sprites.clear();

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -7,8 +7,8 @@
 mod private
 {
   use std::rc::Rc;
-  use std::cell::{ Cell, RefCell };
-  use std::marker::PhantomData;
+  use core::cell::{ Cell, RefCell };
+  use core::marker::PhantomData;
   use web_sys::HtmlImageElement;
   use wasm_bindgen::prelude::*;
   use minwebgl as gl;
@@ -39,6 +39,9 @@ mod private
   impl< T : gl::AsBytes > ArrayBuffer< T >
   {
     /// Creates a new GPU array buffer with the given initial capacity (in elements).
+    ///
+    /// # Errors
+    /// Returns `WebglError` if the underlying GPU buffer cannot be created.
     pub fn new( gl : &gl::GL, capacity : u32 ) -> Result< Self, gl::WebglError >
     {
       let buffer = gl::buffer::create( gl )?;
@@ -52,22 +55,29 @@ mod private
     /// Byte size of one element.
     fn stride() -> u32
     {
-      std::mem::size_of::< T >() as u32
+      core::mem::size_of::< T >() as u32
     }
 
     /// Number of elements currently stored.
+    #[ must_use ]
     pub fn len( &self ) -> u32 { self.len }
 
     /// Whether the buffer is empty.
+    #[ must_use ]
     pub fn is_empty( &self ) -> bool { self.len == 0 }
 
     /// Current capacity in elements.
+    #[ must_use ]
     pub fn capacity( &self ) -> u32 { self.capacity }
 
     /// Returns a reference to the underlying `WebGlBuffer`.
+    #[ must_use ]
     pub fn buffer( &self ) -> &web_sys::WebGlBuffer { &self.buffer }
 
     /// Appends an element at the end, growing if necessary.
+    ///
+    /// # Errors
+    /// Returns `WebglError` if the GPU buffer needs to grow and allocation fails.
     pub fn push( &mut self, value : &T ) -> Result< (), gl::WebglError >
     {
       if self.len >= self.capacity
@@ -97,6 +107,9 @@ mod private
 
     /// Removes the element at `index` by swapping with the last element.
     /// Returns the new length.
+    ///
+    /// # Panics
+    /// Panics if `index >= len`.
     pub fn swap_remove( &mut self, index : u32 ) -> u32
     {
       assert!( index < self.len, "ArrayBuffer::swap_remove index out of bounds" );
@@ -322,10 +335,10 @@ mod private
   }
 
   // Compile-time layout assertions — GPU attrib setup depends on these exact sizes.
-  const _ : () = assert!( std::mem::size_of::< SpriteInstanceData >() == 68 ); // 17 floats × 4
-  const _ : () = assert!( std::mem::size_of::< MeshInstanceData >() == 36 ); // 9 floats × 4
-  const _ : () = assert!( std::mem::align_of::< SpriteInstanceData >() == 4 ); // f32 alignment
-  const _ : () = assert!( std::mem::align_of::< MeshInstanceData >() == 4 );
+  const _ : () = assert!( core::mem::size_of::< SpriteInstanceData >() == 68 ); // 17 floats × 4
+  const _ : () = assert!( core::mem::size_of::< MeshInstanceData >() == 36 ); // 9 floats × 4
+  const _ : () = assert!( core::mem::align_of::< SpriteInstanceData >() == 4 ); // f32 alignment
+  const _ : () = assert!( core::mem::align_of::< MeshInstanceData >() == 4 );
 
   /// Persistent batch — sprite or mesh.
   enum GpuBatch
@@ -350,7 +363,7 @@ mod private
     gl.bind_vertex_array( Some( vao ) );
     gl.bind_buffer( gl::ARRAY_BUFFER, Some( buffer ) );
 
-    let stride = std::mem::size_of::< SpriteInstanceData >() as i32;
+    let stride = core::mem::size_of::< SpriteInstanceData >() as i32;
 
     // transform: 3 × vec3 at locations 0, 1, 2
     for i in 0..3_u32
@@ -406,7 +419,7 @@ mod private
 
     // Instance: transform 3 × vec3 at locations 2, 3, 4
     gl.bind_buffer( gl::ARRAY_BUFFER, Some( instance_buffer ) );
-    let stride = std::mem::size_of::< MeshInstanceData >() as i32;
+    let stride = core::mem::size_of::< MeshInstanceData >() as i32;
     for i in 0..3_u32
     {
       let loc = i + 2;
@@ -449,7 +462,7 @@ mod private
       Ok( Self { program, batch_program } )
     }
 
-    /// Draw a single sprite as a textured quad (triangle strip, 4 vertices from gl_VertexID).
+    /// Draw a single sprite as a textured quad (triangle strip, 4 vertices from `gl_VertexID`).
     fn draw( &self, gl : &gl::GL, transform : &[ f32; 9 ], uv_rect : &[ f32; 4 ], sprite_size : &[ f32; 2 ], tint : &[ f32; 4 ], viewport : &[ f32; 2 ] )
     {
       // Unbind any VAO to prevent stale attribute state from interfering
@@ -535,7 +548,7 @@ mod private
       self.program.uniform_matrix_upload( "u_transform", transform.as_slice(), true );
       self.program.uniform_upload( "u_color", color );
       self.program.uniform_upload( "u_viewport", viewport );
-      self.program.uniform_upload( "u_use_texture", &( use_texture as i32 ) );
+      self.program.uniform_upload( "u_use_texture", &i32::from( use_texture ) );
 
       gl.bind_vertex_array( Some( &geom.vao ) );
 
@@ -561,19 +574,17 @@ mod private
 
       let mut use_texture = false;
       if let Some( tex_id ) = params.texture
+        && let Some( gpu_tex ) = resources.texture( tex_id )
       {
-        if let Some( gpu_tex ) = resources.texture( tex_id )
-        {
-          gl.active_texture( gl::TEXTURE0 );
-          gl.bind_texture( gl::TEXTURE_2D, Some( &gpu_tex.texture ) );
-          use_texture = true;
-        }
+        gl.active_texture( gl::TEXTURE0 );
+        gl.bind_texture( gl::TEXTURE_2D, Some( &gpu_tex.texture ) );
+        use_texture = true;
       }
 
       self.batch_program.activate();
       self.batch_program.uniform_upload( "u_viewport", viewport );
       self.batch_program.uniform_upload( "u_color", &color );
-      self.batch_program.uniform_upload( "u_use_texture", &( use_texture as i32 ) );
+      self.batch_program.uniform_upload( "u_use_texture", &i32::from( use_texture ) );
       let parent_mat = params.transform.to_mat3();
       self.batch_program.uniform_matrix_upload( "u_parent", &parent_mat, true );
 
@@ -661,15 +672,14 @@ mod private
       let gl = &self.gl;
       match blend
       {
-        BlendMode::Normal => gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA ),
         BlendMode::Add => gl.blend_func( gl::SRC_ALPHA, gl::ONE ),
         BlendMode::Multiply => gl.blend_func( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA ),
         BlendMode::Screen => gl.blend_func( gl::ONE, gl::ONE_MINUS_SRC_COLOR ),
         // TODO: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
         // expressed as a single blend_func call — it requires a custom shader or a
         // separate FBO read-back pass, neither of which is implemented yet.
-        // Falls back to Normal so rendering is at least visible.
-        BlendMode::Overlay => gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA ),
+        // Overlay falls back to Normal so rendering is at least visible.
+        BlendMode::Normal | BlendMode::Overlay => gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA ),
       }
     }
 
@@ -1097,42 +1107,36 @@ mod private
             // Positions (attrib 0)
             let mut position_buffer = None;
             if let Some( ref bytes ) = positions
+              && let Ok( buffer ) = gl::buffer::create( gl )
             {
-              if let Ok( buffer ) = gl::buffer::create( gl )
-              {
-                gl::buffer::upload( gl, &buffer, bytes, gl::STATIC_DRAW );
-                gl.enable_vertex_attrib_array( 0 );
-                gl.vertex_attrib_pointer_with_i32( 0, 2, gl::FLOAT, false, 0, 0 );
-                position_buffer = Some( buffer );
-              }
+              gl::buffer::upload( gl, &buffer, bytes, gl::STATIC_DRAW );
+              gl.enable_vertex_attrib_array( 0 );
+              gl.vertex_attrib_pointer_with_i32( 0, 2, gl::FLOAT, false, 0, 0 );
+              position_buffer = Some( buffer );
             }
 
             // UVs (attrib 1)
             let mut uv_buffer = None;
             if let Some( Some( ref bytes ) ) = uvs
+              && let Ok( buffer ) = gl::buffer::create( gl )
             {
-              if let Ok( buffer ) = gl::buffer::create( gl )
-              {
-                gl::buffer::upload( gl, &buffer, bytes, gl::STATIC_DRAW );
-                gl.enable_vertex_attrib_array( 1 );
-                gl.vertex_attrib_pointer_with_i32( 1, 2, gl::FLOAT, false, 0, 0 );
-                uv_buffer = Some( buffer );
-              }
+              gl::buffer::upload( gl, &buffer, bytes, gl::STATIC_DRAW );
+              gl.enable_vertex_attrib_array( 1 );
+              gl.vertex_attrib_pointer_with_i32( 1, 2, gl::FLOAT, false, 0, 0 );
+              uv_buffer = Some( buffer );
             }
 
             // Indices
             let mut index_buffer = None;
             let mut index_count = None;
             if let Some( Some( ref bytes ) ) = indices
+              && let Ok( buffer ) = gl::buffer::create( gl )
             {
-              if let Ok( buffer ) = gl::buffer::create( gl )
-              {
-                gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( &buffer ) );
-                let u8_array = gl::js_sys::Uint8Array::from( bytes.as_slice() );
-                gl.buffer_data_with_array_buffer_view( gl::ELEMENT_ARRAY_BUFFER, &u8_array, gl::STATIC_DRAW );
-                index_count = Some( ( ( bytes.len() as u32 ) / idx_stride, idx_gl_type ) );
-                index_buffer = Some( buffer );
-              }
+              gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( &buffer ) );
+              let u8_array = gl::js_sys::Uint8Array::from( bytes.as_slice() );
+              gl.buffer_data_with_array_buffer_view( gl::ELEMENT_ARRAY_BUFFER, &u8_array, gl::STATIC_DRAW );
+              index_count = Some( ( ( bytes.len() as u32 ) / idx_stride, idx_gl_type ) );
+              index_buffer = Some( buffer );
             }
 
             gl.bind_vertex_array( None );
@@ -1154,11 +1158,9 @@ mod private
                 for batch in res.batches.values()
                 {
                   if let GpuBatch::Mesh { vao, params, instances, .. } = batch
+                    && params.geometry == id
                   {
-                    if params.geometry == id
-                    {
-                      setup_mesh_batch_vao( gl, vao, geom, instances.buffer() );
-                    }
+                    setup_mesh_batch_vao( gl, vao, geom, instances.buffer() );
                   }
                 }
               }
@@ -1394,7 +1396,7 @@ mod private
     {
       web_sys::console::error_1
       (
-        &format!( "tilemap_renderer: failed to load image from path {:?}", src_for_err ).into()
+        &format!( "tilemap_renderer: failed to load image from path {src_for_err:?}" ).into()
       );
     });
 
@@ -1431,7 +1433,7 @@ mod private
     {
       SamplerFilter::Nearest => gl::texture::d2::filter_nearest( gl ),
       SamplerFilter::Linear => gl::texture::d2::filter_linear( gl ),
-    };
+    }
   }
 
   fn topology_to_gl( t : &Topology ) -> u32

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -26,11 +26,16 @@ mod private
   ///
   /// Stores elements of type `T` in a WebGL `ARRAY_BUFFER`.
   /// Tracks length and capacity; grows by 2× when full using
-  /// `copy_buffer_sub_data` (GPU-to-GPU, no CPU readback).
+  /// `copy_buffer_sub_data` (GPU-to-GPU copy into a freshly allocated buffer).
+  /// `swap_remove` uses a persistent one-element scratch buffer as an intermediary
+  /// to avoid the WebGL2 spec violation of binding the same buffer to both
+  /// `COPY_READ_BUFFER` and `COPY_WRITE_BUFFER` simultaneously.
   pub struct ArrayBuffer< T >
   {
     gl : gl::GL,
     buffer : web_sys::WebGlBuffer,
+    /// One-element scratch buffer used by `swap_remove` as a GPU-side intermediary.
+    scratch : web_sys::WebGlBuffer,
     len : u32,
     capacity : u32,
     _marker : PhantomData< T >,
@@ -49,7 +54,13 @@ mod private
       gl.bind_buffer( gl::ARRAY_BUFFER, Some( &buffer ) );
       gl.buffer_data_with_i32( gl::ARRAY_BUFFER, byte_size as i32, gl::DYNAMIC_DRAW );
       gl.bind_buffer( gl::ARRAY_BUFFER, None );
-      Ok( Self { gl : gl.clone(), buffer, len : 0, capacity, _marker : PhantomData } )
+
+      let scratch = gl::buffer::create( gl )?;
+      gl.bind_buffer( gl::ARRAY_BUFFER, Some( &scratch ) );
+      gl.buffer_data_with_i32( gl::ARRAY_BUFFER, Self::stride() as i32, gl::DYNAMIC_DRAW );
+      gl.bind_buffer( gl::ARRAY_BUFFER, None );
+
+      Ok( Self { gl : gl.clone(), buffer, scratch, len : 0, capacity, _marker : PhantomData } )
     }
 
     /// Byte size of one element.
@@ -120,13 +131,27 @@ mod private
         let src_offset = self.len as i32 * stride;
         let dst_offset = index as i32 * stride;
 
+        // Binding the same buffer to both COPY_READ_BUFFER and COPY_WRITE_BUFFER is a
+        // WebGL2 spec violation (INVALID_OPERATION). Use a persistent one-element scratch
+        // buffer as an intermediary: last → scratch → removed slot. Both copies use
+        // distinct buffer objects, so the spec is satisfied and the copies are GPU-only.
         self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.buffer ) );
-        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &self.buffer ) );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &self.scratch ) );
         self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
         (
           gl::COPY_READ_BUFFER,
           gl::COPY_WRITE_BUFFER,
           src_offset,
+          0,
+          stride,
+        );
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.scratch ) );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &self.buffer ) );
+        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
+        (
+          gl::COPY_READ_BUFFER,
+          gl::COPY_WRITE_BUFFER,
+          0,
           dst_offset,
           stride,
         );
@@ -176,6 +201,7 @@ mod private
     fn drop( &mut self )
     {
       self.gl.delete_buffer( Some( &self.buffer ) );
+      self.gl.delete_buffer( Some( &self.scratch ) );
     }
   }
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -291,6 +291,7 @@ mod private
     width : Cell< u32 >,
     height : Cell< u32 >,
     _filter : SamplerFilter,
+    _mipmap : MipmapMode,
   }
 
   impl Drop for GpuTexture
@@ -1096,14 +1097,28 @@ mod private
           {
             let path = path.as_path().to_str()
               .ok_or_else( || RenderError::BackendError( "non-UTF-8 image path".into() ) )?;
-            let tex = upload_image_from_path( gl, path, img.id, &self.resources );
+            // Async path: sampler state (filter, wrap, mipmap chain) is applied inside
+            // the on_load callback after the image bytes are actually uploaded, so the
+            // texture is guaranteed to be complete (esp. for mipmap modes, which leave
+            // the texture incomplete until generate_mipmap runs).
+            let tex = upload_image_from_path( gl, path, img.id, &self.resources, img.filter, img.mipmap );
             gl.bind_texture( gl::TEXTURE_2D, Some( &tex ) );
             ( tex, 0, 0 )
           }
         };
 
-        apply_texture_filter( gl, &img.filter );
-        gl::texture::d2::wrap_clamp( gl );
+        // Sync bitmap path: level 0 is already uploaded; apply sampler state and
+        // generate the mip chain right away so the texture is immediately usable.
+        // (The async Path branch does all of this inside on_load.)
+        if matches!( img.source, crate::assets::ImageSource::Bitmap { .. } )
+        {
+          apply_texture_filter( gl, &img.filter, &img.mipmap );
+          gl::texture::d2::wrap_clamp( gl );
+          if !matches!( img.mipmap, MipmapMode::Off )
+          {
+            gl.generate_mipmap( gl::TEXTURE_2D );
+          }
+        }
 
         self.resources.borrow_mut().store_texture( img.id, GpuTexture
         {
@@ -1112,6 +1127,7 @@ mod private
           width : Cell::new( w ),
           height : Cell::new( h ),
           _filter : img.filter,
+          _mipmap : img.mipmap,
         });
       }
 
@@ -1453,6 +1469,8 @@ mod private
     src : &str,
     id : ResourceId< asset::Image >,
     resources : &Rc< RefCell< GpuResources > >,
+    filter : SamplerFilter,
+    mipmap : MipmapMode,
   ) -> web_sys::WebGlTexture
   {
     let document = web_sys::window().expect( "no window" ).document().expect( "no document" );
@@ -1474,6 +1492,20 @@ mod private
       move ||
       {
         gl::texture::d2::upload( &gl, Some( &texture ), &img );
+
+        // Bind and apply all sampler state now that level 0 is populated. Binding
+        // explicitly because upload() may leave a different texture bound, and
+        // tex_parameteri / generate_mipmap act on whatever is bound to TEXTURE_2D.
+        // Applying filter here (not only at texture creation) ensures the correct
+        // mag/min filters are installed on the texture object regardless of any
+        // intervening bind changes — belt-and-suspenders for the async path.
+        gl.bind_texture( gl::TEXTURE_2D, Some( &texture ) );
+        apply_texture_filter( &gl, &filter, &mipmap );
+        gl::texture::d2::wrap_clamp( &gl );
+        if !matches!( mipmap, MipmapMode::Off )
+        {
+          gl.generate_mipmap( gl::TEXTURE_2D );
+        }
 
         if let Some( gpu_tex ) = resources.borrow().texture( id )
         {
@@ -1528,13 +1560,29 @@ mod private
     }
   }
 
-  fn apply_texture_filter( gl : &gl::GL, filter : &SamplerFilter )
+  /// Sets mag/min filter on the currently bound TEXTURE_2D based on `filter` and `mipmap`.
+  /// Caller is responsible for calling `generate_mipmap` separately when `mipmap != Off`
+  /// (after the level-0 upload completes — on the async path that's inside the on_load callback).
+  fn apply_texture_filter( gl : &gl::GL, filter : &SamplerFilter, mipmap : &MipmapMode )
   {
-    match filter
+    // mag_filter ignores mipmaps — magnification samples only level 0.
+    let mag = match filter
     {
-      SamplerFilter::Nearest => gl::texture::d2::filter_nearest( gl ),
-      SamplerFilter::Linear => gl::texture::d2::filter_linear( gl ),
-    }
+      SamplerFilter::Nearest => gl::NEAREST,
+      SamplerFilter::Linear => gl::LINEAR,
+    };
+    // min_filter combines within-level interpolation with between-level interpolation.
+    let min = match ( filter, mipmap )
+    {
+      ( SamplerFilter::Nearest, MipmapMode::Off )     => gl::NEAREST,
+      ( SamplerFilter::Linear,  MipmapMode::Off )     => gl::LINEAR,
+      ( SamplerFilter::Nearest, MipmapMode::Nearest ) => gl::NEAREST_MIPMAP_NEAREST,
+      ( SamplerFilter::Linear,  MipmapMode::Nearest ) => gl::LINEAR_MIPMAP_NEAREST,
+      ( SamplerFilter::Nearest, MipmapMode::Linear )  => gl::NEAREST_MIPMAP_LINEAR,
+      ( SamplerFilter::Linear,  MipmapMode::Linear )  => gl::LINEAR_MIPMAP_LINEAR,
+    };
+    gl.tex_parameteri( gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, mag as i32 );
+    gl.tex_parameteri( gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, min as i32 );
   }
 
   fn topology_to_gl( t : &Topology ) -> u32

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1310,6 +1310,9 @@ mod private
 
       for cmd in commands
       {
+        // Unimplemented placeholder arms (Path/Text/Group) all map to {} and are
+        // intentionally kept separate for readability and future expansion.
+        #[ allow( clippy::match_same_arms ) ]
         match cmd
         {
           RenderCommand::Clear( c ) => self.cmd_clear( c ),

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -773,11 +773,12 @@ mod private
       self.sprite.draw( &self.gl, &mat, &uv_rect, &sprite_size, &s.tint, viewport );
     }
 
-    fn cmd_create_sprite_batch( &mut self, cmd : &CreateSpriteBatch )
+    fn cmd_create_sprite_batch( &mut self, cmd : &CreateSpriteBatch ) -> Result< (), RenderError >
     {
+      let map_err = | e : gl::WebglError | RenderError::BackendError( format!( "{e:?}" ) );
       let gl = &self.gl;
-      let Ok( instances ) = ArrayBuffer::< SpriteInstanceData >::new( gl, 16 ) else { return };
-      let Ok( vao ) = gl::vao::create( gl ) else { return };
+      let instances = ArrayBuffer::< SpriteInstanceData >::new( gl, 16 ).map_err( map_err )?;
+      let vao = gl::vao::create( gl ).map_err( map_err )?;
       setup_sprite_batch_vao( gl, &vao, instances.buffer() );
       self.resources.borrow_mut().store_batch( cmd.batch, GpuBatch::Sprite
       {
@@ -785,13 +786,15 @@ mod private
         vao,
         params : cmd.params,
       });
+      Ok( () )
     }
 
-    fn cmd_create_mesh_batch( &mut self, cmd : &CreateMeshBatch )
+    fn cmd_create_mesh_batch( &mut self, cmd : &CreateMeshBatch ) -> Result< (), RenderError >
     {
+      let map_err = | e : gl::WebglError | RenderError::BackendError( format!( "{e:?}" ) );
       let gl = &self.gl;
-      let Ok( instances ) = ArrayBuffer::< MeshInstanceData >::new( gl, 16 ) else { return };
-      let Ok( vao ) = gl::vao::create( gl ) else { return };
+      let instances = ArrayBuffer::< MeshInstanceData >::new( gl, 16 ).map_err( map_err )?;
+      let vao = gl::vao::create( gl ).map_err( map_err )?;
       let res = self.resources.borrow();
       if let Some( geom ) = res.geometry( cmd.params.geometry )
       {
@@ -804,6 +807,7 @@ mod private
         vao,
         params : cmd.params,
       });
+      Ok( () )
     }
 
     fn cmd_bind_batch( &mut self, cmd : &BindBatch ) -> Result< (), RenderError >
@@ -1287,8 +1291,8 @@ mod private
           RenderCommand::Sprite( s ) => self.cmd_sprite( s, &viewport ),
 
           // Batch lifecycle
-          RenderCommand::CreateSpriteBatch( c ) => self.cmd_create_sprite_batch( c ),
-          RenderCommand::CreateMeshBatch( c ) => self.cmd_create_mesh_batch( c ),
+          RenderCommand::CreateSpriteBatch( c ) => self.cmd_create_sprite_batch( c )?,
+          RenderCommand::CreateMeshBatch( c ) => self.cmd_create_mesh_batch( c )?,
           RenderCommand::BindBatch( b ) => self.cmd_bind_batch( b )?,
           RenderCommand::AddSpriteInstance( si ) => self.cmd_add_sprite_instance( si )?,
           RenderCommand::AddMeshInstance( mi ) => self.cmd_add_mesh_instance( mi )?,

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -707,6 +707,8 @@ mod private
       match blend
       {
         BlendMode::Add => gl.blend_func( gl::SRC_ALPHA, gl::ONE ),
+        // Approximation: equals src*dst only when src_alpha=1.
+        // TODO(FBO): replace with Photoshop-accurate formula — see BlendMode::Multiply doc.
         BlendMode::Multiply => gl.blend_func( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA ),
         BlendMode::Screen => gl.blend_func( gl::ONE, gl::ONE_MINUS_SRC_COLOR ),
         // TODO: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -665,6 +665,11 @@ mod private
   {
     /// Creates a new WebGL backend.
     ///
+    /// **Antialiasing note:** MSAA in WebGL2 is controlled by the `antialias` attribute
+    /// passed to `getContext("webgl2", { antialias: true })` at context creation time,
+    /// not by `RenderConfig::antialias`. That field is only meaningful for the SVG adapter.
+    /// Pass the desired AA setting when creating the WebGL2 context before calling this.
+    ///
     /// # Errors
     /// Returns error if shader compilation fails.
     pub fn new( config : RenderConfig, gl : gl::GL ) -> Result< Self, RenderError >

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -663,6 +663,10 @@ mod private
         BlendMode::Add => gl.blend_func( gl::SRC_ALPHA, gl::ONE ),
         BlendMode::Multiply => gl.blend_func( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA ),
         BlendMode::Screen => gl.blend_func( gl::ONE, gl::ONE_MINUS_SRC_COLOR ),
+        // TODO: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
+        // expressed as a single blend_func call — it requires a custom shader or a
+        // separate FBO read-back pass, neither of which is implemented yet.
+        // Falls back to Normal so rendering is at least visible.
         BlendMode::Overlay => gl.blend_func( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA ),
       }
     }
@@ -1234,7 +1238,7 @@ mod private
         patterns : false,    // TODO: not yet loaded or rendered
         clip_masks : false,  // TODO: not yet loaded or rendered
         effects : false,     // TODO: requires FBO post-processing
-        blend_modes : true,
+        blend_modes : true,  // Normal/Add/Multiply/Screen work; Overlay falls back to Normal (needs custom shader)
         text_on_path : false,
         max_texture_size : 8192,
       }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -142,7 +142,7 @@ mod private
       (
         gl.clone(),
         include_str!( "shaders/mesh_batch.vert" ),
-        include_str!( "shaders/mesh.frag" ),
+        include_str!( "shaders/mesh_batch.frag" ),
       )?;
       Ok( Self { program, batch_program } )
     }
@@ -498,7 +498,7 @@ mod private
     fn cmd_add_mesh_instance( &mut self, mi : &AddMeshInstance ) -> Result< (), RenderError >
     {
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
-      let data = MeshInstanceData { transform : mi.transform.to_mat3(), depth : mi.transform.depth };
+      let data = MeshInstanceData { transform : mi.transform.to_mat3(), depth : mi.transform.depth, tint : mi.tint };
       let mut res = self.resources.borrow_mut();
       match res.batch_mut( batch_id )
       {
@@ -570,7 +570,7 @@ mod private
     fn cmd_set_mesh_instance( &mut self, mi : &SetMeshInstance ) -> Result< (), RenderError >
     {
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
-      let data = MeshInstanceData { transform : mi.transform.to_mat3(), depth : mi.transform.depth };
+      let data = MeshInstanceData { transform : mi.transform.to_mat3(), depth : mi.transform.depth, tint : mi.tint };
       let mut res = self.resources.borrow_mut();
       match res.batch_mut( batch_id )
       {

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -781,6 +781,24 @@ mod private
     }
 
     // ---- Command handlers ----
+    //
+    // Contract for batch-targeting commands (cmd_add_*_instance, cmd_set_*_instance,
+    // cmd_set_*_batch_params, cmd_remove_instance, cmd_draw_batch):
+    //
+    // - `recording_batch == None` (no active BindBatch, or called after UnbindBatch):
+    //   silently return Ok(()). Mid-frame state transitions can legitimately leave
+    //   this slot empty; making every add/set/remove a hard error would require the
+    //   caller to mirror the bind-state machine.
+    //
+    // - Referenced id not found in the resource map (batch / sprite / geometry):
+    //   emit a console.warn and return Ok(()). Async asset loading can legitimately
+    //   leave an id unresolved for a short window, and we prefer a visible
+    //   diagnostic over a hard error that would tear down the whole submit().
+    //
+    // - Referenced batch exists but has the WRONG variant (Sprite-targeting command
+    //   hits a Mesh batch or vice versa): return Err. Batch variant is assigned at
+    //   CreateSpriteBatch / CreateMeshBatch time — synchronous and never racy — so a
+    //   mismatch is a genuine caller bug that should surface immediately.
 
     fn cmd_clear( &self, c : &Clear )
     {
@@ -890,16 +908,36 @@ mod private
     {
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let mut res = self.resources.borrow_mut();
-      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region ) else { return Ok( () ) };
+      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region )
+      else
+      {
+        web_sys::console::warn_1
+        (
+          &format!( "AddSpriteInstance: sprite {:?} not found (dropped)", si.sprite ).into()
+        );
+        return Ok( () );
+      };
       let data = SpriteInstanceData
       {
         transform : si.transform.to_mat3(),
         region,
         tint : si.tint,
       };
-      if let Some( GpuBatch::Sprite { instances, .. } ) = res.batch_mut( batch_id )
+      match res.batch_mut( batch_id )
       {
-        instances.push( &data ).map_err( | e | RenderError::BackendError( e.to_string() ) )?;
+        Some( GpuBatch::Sprite { instances, .. } ) =>
+          instances.push( &data ).map_err( | e | RenderError::BackendError( e.to_string() ) )?,
+        Some( GpuBatch::Mesh { .. } ) => return Err( RenderError::BackendError
+        (
+          format!( "AddSpriteInstance: batch {:?} is a Mesh batch; sprite instances require a Sprite batch", batch_id )
+        )),
+        None =>
+        {
+          web_sys::console::warn_1
+          (
+            &format!( "AddSpriteInstance: batch {:?} not found (dropped)", batch_id ).into()
+          );
+        }
       }
       Ok( () )
     }
@@ -909,9 +947,21 @@ mod private
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let data = MeshInstanceData { transform : mi.transform.to_mat3() };
       let mut res = self.resources.borrow_mut();
-      if let Some( GpuBatch::Mesh { instances, .. } ) = res.batch_mut( batch_id )
+      match res.batch_mut( batch_id )
       {
-        instances.push( &data ).map_err( | e | RenderError::BackendError( e.to_string() ) )?;
+        Some( GpuBatch::Mesh { instances, .. } ) =>
+          instances.push( &data ).map_err( | e | RenderError::BackendError( e.to_string() ) )?,
+        Some( GpuBatch::Sprite { .. } ) => return Err( RenderError::BackendError
+        (
+          format!( "AddMeshInstance: batch {:?} is a Sprite batch; mesh instances require a Mesh batch", batch_id )
+        )),
+        None =>
+        {
+          web_sys::console::warn_1
+          (
+            &format!( "AddMeshInstance: batch {:?} not found (dropped)", batch_id ).into()
+          );
+        }
       }
       Ok( () )
     }
@@ -920,23 +970,45 @@ mod private
     {
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let mut res = self.resources.borrow_mut();
-      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region ) else { return Ok( () ) };
+      let Some( region ) = res.sprite( si.sprite ).map( | s | s.region )
+      else
+      {
+        web_sys::console::warn_1
+        (
+          &format!( "SetSpriteInstance: sprite {:?} not found (dropped)", si.sprite ).into()
+        );
+        return Ok( () );
+      };
       let data = SpriteInstanceData
       {
         transform : si.transform.to_mat3(),
         region,
         tint : si.tint,
       };
-      if let Some( GpuBatch::Sprite { instances, .. } ) = res.batch_mut( batch_id )
+      match res.batch_mut( batch_id )
       {
-        if si.index >= instances.len()
+        Some( GpuBatch::Sprite { instances, .. } ) =>
         {
-          return Err( RenderError::BackendError
-          (
-            format!( "SetSpriteInstance: index {} out of bounds (len {})", si.index, instances.len() )
-          ));
+          if si.index >= instances.len()
+          {
+            return Err( RenderError::BackendError
+            (
+              format!( "SetSpriteInstance: index {} out of bounds (len {})", si.index, instances.len() )
+            ));
+          }
+          instances.set( si.index, &data );
         }
-        instances.set( si.index, &data );
+        Some( GpuBatch::Mesh { .. } ) => return Err( RenderError::BackendError
+        (
+          format!( "SetSpriteInstance: batch {:?} is a Mesh batch; sprite instances require a Sprite batch", batch_id )
+        )),
+        None =>
+        {
+          web_sys::console::warn_1
+          (
+            &format!( "SetSpriteInstance: batch {:?} not found (dropped)", batch_id ).into()
+          );
+        }
       }
       Ok( () )
     }
@@ -946,16 +1018,30 @@ mod private
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let data = MeshInstanceData { transform : mi.transform.to_mat3() };
       let mut res = self.resources.borrow_mut();
-      if let Some( GpuBatch::Mesh { instances, .. } ) = res.batch_mut( batch_id )
+      match res.batch_mut( batch_id )
       {
-        if mi.index >= instances.len()
+        Some( GpuBatch::Mesh { instances, .. } ) =>
         {
-          return Err( RenderError::BackendError
-          (
-            format!( "SetMeshInstance: index {} out of bounds (len {})", mi.index, instances.len() )
-          ));
+          if mi.index >= instances.len()
+          {
+            return Err( RenderError::BackendError
+            (
+              format!( "SetMeshInstance: index {} out of bounds (len {})", mi.index, instances.len() )
+            ));
+          }
+          instances.set( mi.index, &data );
         }
-        instances.set( mi.index, &data );
+        Some( GpuBatch::Sprite { .. } ) => return Err( RenderError::BackendError
+        (
+          format!( "SetMeshInstance: batch {:?} is a Sprite batch; mesh instances require a Mesh batch", batch_id )
+        )),
+        None =>
+        {
+          web_sys::console::warn_1
+          (
+            &format!( "SetMeshInstance: batch {:?} not found (dropped)", batch_id ).into()
+          );
+        }
       }
       Ok( () )
     }
@@ -964,47 +1050,80 @@ mod private
     {
       let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let mut res = self.resources.borrow_mut();
-      if let Some( batch ) = res.batch_mut( batch_id )
+      let Some( batch ) = res.batch_mut( batch_id )
+      else
       {
-        let len = match batch
+        web_sys::console::warn_1
+        (
+          &format!( "RemoveInstance: batch {:?} not found (dropped)", batch_id ).into()
+        );
+        return Ok( () );
+      };
+      // RemoveInstance is polymorphic — it doesn't care whether the batch is
+      // Sprite or Mesh, only that the index is in-bounds — so no type-mismatch
+      // branch here.
+      let len = match batch
+      {
+        GpuBatch::Sprite { instances, .. } => instances.len(),
+        GpuBatch::Mesh { instances, .. } => instances.len(),
+      };
+      if ri.index >= len
+      {
+        return Err( RenderError::BackendError
+        (
+          format!( "RemoveInstance: index {} out of bounds (len {})", ri.index, len )
+        ));
+      }
+      match batch
+      {
+        GpuBatch::Sprite { instances, .. } => { instances.swap_remove( ri.index ); },
+        GpuBatch::Mesh { instances, .. } => { instances.swap_remove( ri.index ); },
+      }
+      Ok( () )
+    }
+
+    fn cmd_set_sprite_batch_params( &mut self, cmd : &SetSpriteBatchParams ) -> Result< (), RenderError >
+    {
+      let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
+      let mut res = self.resources.borrow_mut();
+      match res.batch_mut( batch_id )
+      {
+        Some( GpuBatch::Sprite { params, .. } ) => { *params = cmd.params; }
+        Some( GpuBatch::Mesh { .. } ) => return Err( RenderError::BackendError
+        (
+          format!( "SetSpriteBatchParams: batch {:?} is a Mesh batch", batch_id )
+        )),
+        None =>
         {
-          GpuBatch::Sprite { instances, .. } => instances.len(),
-          GpuBatch::Mesh { instances, .. } => instances.len(),
-        };
-        if ri.index >= len
-        {
-          return Err( RenderError::BackendError
+          web_sys::console::warn_1
           (
-            format!( "RemoveInstance: index {} out of bounds (len {})", ri.index, len )
-          ));
-        }
-        match batch
-        {
-          GpuBatch::Sprite { instances, .. } => { instances.swap_remove( ri.index ); },
-          GpuBatch::Mesh { instances, .. } => { instances.swap_remove( ri.index ); },
+            &format!( "SetSpriteBatchParams: batch {:?} not found (dropped)", batch_id ).into()
+          );
         }
       }
       Ok( () )
     }
 
-    fn cmd_set_sprite_batch_params( &mut self, cmd : &SetSpriteBatchParams )
+    fn cmd_set_mesh_batch_params( &mut self, cmd : &SetMeshBatchParams ) -> Result< (), RenderError >
     {
-      let Some( batch_id ) = self.recording_batch else { return };
+      let Some( batch_id ) = self.recording_batch else { return Ok( () ) };
       let mut res = self.resources.borrow_mut();
-      if let Some( GpuBatch::Sprite { params, .. } ) = res.batch_mut( batch_id )
+      match res.batch_mut( batch_id )
       {
-        *params = cmd.params;
+        Some( GpuBatch::Mesh { params, .. } ) => { *params = cmd.params; }
+        Some( GpuBatch::Sprite { .. } ) => return Err( RenderError::BackendError
+        (
+          format!( "SetMeshBatchParams: batch {:?} is a Sprite batch", batch_id )
+        )),
+        None =>
+        {
+          web_sys::console::warn_1
+          (
+            &format!( "SetMeshBatchParams: batch {:?} not found (dropped)", batch_id ).into()
+          );
+        }
       }
-    }
-
-    fn cmd_set_mesh_batch_params( &mut self, cmd : &SetMeshBatchParams )
-    {
-      let Some( batch_id ) = self.recording_batch else { return };
-      let mut res = self.resources.borrow_mut();
-      if let Some( GpuBatch::Mesh { params, .. } ) = res.batch_mut( batch_id )
-      {
-        *params = cmd.params;
-      }
+      Ok( () )
     }
 
     fn cmd_unbind_batch( &mut self )
@@ -1042,18 +1161,24 @@ mod private
         ));
       }
       let res = self.resources.borrow();
-      if let Some( gpu_batch ) = res.batch( db.batch )
+      let Some( gpu_batch ) = res.batch( db.batch )
+      else
       {
-        self.apply_blend( match gpu_batch
-        {
-          GpuBatch::Sprite { params, .. } => &params.blend,
-          GpuBatch::Mesh { params, .. } => &params.blend,
-        });
-        match gpu_batch
-        {
-          GpuBatch::Sprite { .. } => self.sprite.draw_batch( &self.gl, gpu_batch, &res, viewport ),
-          GpuBatch::Mesh { .. } => self.mesh.draw_batch( &self.gl, gpu_batch, &res, viewport ),
-        }
+        web_sys::console::warn_1
+        (
+          &format!( "DrawBatch: batch {:?} not found (dropped)", db.batch ).into()
+        );
+        return Ok( () );
+      };
+      self.apply_blend( match gpu_batch
+      {
+        GpuBatch::Sprite { params, .. } => &params.blend,
+        GpuBatch::Mesh { params, .. } => &params.blend,
+      });
+      match gpu_batch
+      {
+        GpuBatch::Sprite { .. } => self.sprite.draw_batch( &self.gl, gpu_batch, &res, viewport ),
+        GpuBatch::Mesh { .. } => self.mesh.draw_batch( &self.gl, gpu_batch, &res, viewport ),
       }
       Ok( () )
     }
@@ -1463,8 +1588,8 @@ mod private
           RenderCommand::SetSpriteInstance( si ) => self.cmd_set_sprite_instance( si )?,
           RenderCommand::SetMeshInstance( mi ) => self.cmd_set_mesh_instance( mi )?,
           RenderCommand::RemoveInstance( ri ) => self.cmd_remove_instance( ri )?,
-          RenderCommand::SetSpriteBatchParams( sp ) => self.cmd_set_sprite_batch_params( sp ),
-          RenderCommand::SetMeshBatchParams( mp ) => self.cmd_set_mesh_batch_params( mp ),
+          RenderCommand::SetSpriteBatchParams( sp ) => self.cmd_set_sprite_batch_params( sp )?,
+          RenderCommand::SetMeshBatchParams( mp ) => self.cmd_set_mesh_batch_params( mp )?,
           RenderCommand::UnbindBatch( _ ) => self.cmd_unbind_batch(),
           RenderCommand::DrawBatch( db ) => self.cmd_draw_batch( db, &viewport )?,
           RenderCommand::DeleteBatch( db ) => self.cmd_delete_batch( db ),

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -952,12 +952,20 @@ mod private
               crate::assets::PixelFormat::GrayAlpha8 => gl::LUMINANCE_ALPHA,
             };
 
-            let _ = gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array
+            gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array
             (
               gl::TEXTURE_2D, 0, gl_fmt as i32,
               *width as i32, *height as i32, 0,
               gl_fmt, gl::UNSIGNED_BYTE, Some( bytes ),
-            );
+            )
+            .map_err( | e | RenderError::BackendError
+            (
+              format!
+              (
+                "tex_image_2d failed for image {:?}: {:?}",
+                img.id, e
+              )
+            ))?;
 
             ( tex, *width, *height )
           }
@@ -1339,9 +1347,20 @@ mod private
       }
     });
 
+    let src_for_err = src.to_owned();
+    let on_error : Closure< dyn Fn() > = Closure::new( move ||
+    {
+      web_sys::console::error_1
+      (
+        &format!( "tilemap_renderer: failed to load image from path {:?}", src_for_err ).into()
+      );
+    });
+
     img.set_onload( Some( on_load.as_ref().unchecked_ref() ) );
+    img.set_onerror( Some( on_error.as_ref().unchecked_ref() ) );
     img.set_src( src );
     on_load.forget();
+    on_error.forget();
 
     texture
   }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -618,6 +618,10 @@ mod private
       {
         gl.draw_arrays( topology, 0, geom.vertex_count as i32 );
       }
+      // Unbind the geometry VAO so a subsequent `vertex_attrib_pointer` call
+      // (e.g. during `setup_mesh_batch_vao` for another batch) cannot silently
+      // mutate this geometry's attribute layout.
+      gl.bind_vertex_array( None );
     }
 
     /// Draw an instanced mesh batch. VAO is already configured via `setup_mesh_batch_vao`.
@@ -658,8 +662,9 @@ mod private
       }
       // Unbind the batch VAO so subsequent GL state setup (e.g. a later
       // vertex_attrib_pointer call during batch construction) cannot
-      // accidentally mutate this batch's attribute layout. Matches the
-      // single-draw path which also leaves VAO 0 bound.
+      // accidentally mutate this batch's attribute layout. The single-draw
+      // path (`MeshRenderer::draw`) likewise unbinds on exit, so both mesh
+      // draw paths leave VAO 0 bound.
       gl.bind_vertex_array( None );
     }
   }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -111,8 +111,9 @@ mod private
       gl.draw_arrays_instanced( gl::TRIANGLE_STRIP, 0, 4, instances.len() as i32 );
       // Unbind the batch VAO so subsequent GL state setup (e.g. a later
       // vertex_attrib_pointer call during batch construction) cannot
-      // accidentally mutate this batch's attribute layout. Matches the
-      // single-draw path which also leaves VAO 0 bound.
+      // accidentally mutate this batch's attribute layout. The single-draw
+      // path (`SpriteRenderer::draw`) likewise unbinds on exit, so both
+      // sprite draw paths leave VAO 0 bound.
       gl.bind_vertex_array( None );
     }
   }

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -223,6 +223,10 @@ mod private
     sprites : IntMap< ResourceId< asset::Sprite >, GpuSprite >,
     geometries : IntMap< ResourceId< asset::Geometry >, GpuGeometry >,
     batches : IntMap< ResourceId< Batch >, GpuBatch >,
+    /// Incremented on every `load_assets` call. In-flight `spawn_local` futures
+    /// from a previous cycle capture the old value and bail out on resolve,
+    /// so stale async data cannot overwrite freshly-loaded entries.
+    generation : u32,
   }
 
   impl GpuResources
@@ -235,6 +239,7 @@ mod private
         sprites : IntMap::default(),
         geometries : IntMap::default(),
         batches : IntMap::default(),
+        generation : 0,
       }
     }
 
@@ -1101,7 +1106,8 @@ mod private
             // the on_load callback after the image bytes are actually uploaded, so the
             // texture is guaranteed to be complete (esp. for mipmap modes, which leave
             // the texture incomplete until generate_mipmap runs).
-            let tex = upload_image_from_path( gl, path, img.id, &self.resources, img.filter, img.mipmap );
+            let generation = self.resources.borrow().generation;
+            let tex = upload_image_from_path( gl, path, img.id, &self.resources, img.filter, img.mipmap, generation );
             gl.bind_texture( gl::TEXTURE_2D, Some( &tex ) );
             ( tex, 0, 0 )
           }
@@ -1191,6 +1197,7 @@ mod private
           let gl_clone = gl.clone();
           let resources = Rc::clone( &self.resources );
           let id = geom.id;
+          let generation = self.resources.borrow().generation;
 
           let positions_source = source_to_loadable( &geom.positions );
           let uvs_source = geom.uvs.as_ref().map( source_to_loadable );
@@ -1203,6 +1210,10 @@ mod private
             let positions = resolve_loadable( positions_source ).await;
             let uvs = match uvs_source { Some( s ) => Some( resolve_loadable( s ).await ), None => None };
             let indices = match indices_source { Some( s ) => Some( resolve_loadable( s ).await ), None => None };
+
+            // Bail out if `load_assets` ran again while we were fetching — this future
+            // belongs to a previous cycle and must not overwrite fresh entries.
+            if resources.borrow().generation != generation { return; }
 
             // Create a fresh VAO for the populated entry — distinct from the placeholder's,
             // so placeholder drop can't delete the GPU object this entry depends on.
@@ -1338,7 +1349,15 @@ mod private
       // Reset all GPU state: textures, sprites, geometries, and batches.
       // GpuBatch::drop calls delete_vertex_array; ArrayBuffer::drop calls delete_buffer.
       // Safe to call multiple times (e.g. level transitions).
-      self.resources.borrow_mut().batches.clear();
+      //
+      // Bump the generation counter so any in-flight `spawn_local` futures from
+      // a previous cycle notice they are stale and bail out before overwriting
+      // entries belonging to this new cycle.
+      {
+        let mut res = self.resources.borrow_mut();
+        res.generation = res.generation.wrapping_add( 1 );
+        res.batches.clear();
+      }
       // Clear the stale recording batch ID: the referenced batch no longer exists,
       // so leaving it set would make cmd_bind_batch reject any new bind on the next frame.
       self.recording_batch = None;
@@ -1477,6 +1496,7 @@ mod private
     resources : &Rc< RefCell< GpuResources > >,
     filter : SamplerFilter,
     mipmap : MipmapMode,
+    generation : u32,
   ) -> web_sys::WebGlTexture
   {
     let document = web_sys::window().expect( "no window" ).document().expect( "no document" );
@@ -1497,6 +1517,15 @@ mod private
       let resources = Rc::clone( resources );
       move ||
       {
+        // Bail out if `load_assets` ran again before the image finished loading —
+        // this closure belongs to a previous cycle and must not touch the fresh
+        // texture that now occupies this id.
+        if resources.borrow().generation != generation
+        {
+          img.remove();
+          return;
+        }
+
         gl::texture::d2::upload( &gl, Some( &texture ), &img );
 
         // Bind and apply all sampler state now that level 0 is populated. Binding

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1177,12 +1177,14 @@ mod private
 
         if has_path
         {
-          // Create empty VAO and register geometry immediately so the id is available.
-          // The spawn_local future will fetch data and populate the VAO later.
-          let vao = gl::vao::create( gl ).map_err( map_err )?;
+          // Register a placeholder geometry immediately so the id is available.
+          // The placeholder owns its own VAO (never shared): when `store_geometry`
+          // later replaces it, its `Drop` deletes *this* VAO, not the populated one.
+          // The spawn_local future creates a separate VAO for the populated entry.
+          let placeholder_vao = gl::vao::create( gl ).map_err( map_err )?;
           self.resources.borrow_mut().store_geometry( geom.id, GpuGeometry
           {
-            gl : gl.clone(), vao : vao.clone(), position_buffer : None, uv_buffer : None, index_buffer : None,
+            gl : gl.clone(), vao : placeholder_vao, position_buffer : None, uv_buffer : None, index_buffer : None,
             vertex_count : 0, index_count : None,
           });
 
@@ -1201,6 +1203,10 @@ mod private
             let positions = resolve_loadable( positions_source ).await;
             let uvs = match uvs_source { Some( s ) => Some( resolve_loadable( s ).await ), None => None };
             let indices = match indices_source { Some( s ) => Some( resolve_loadable( s ).await ), None => None };
+
+            // Create a fresh VAO for the populated entry — distinct from the placeholder's,
+            // so placeholder drop can't delete the GPU object this entry depends on.
+            let Ok( vao ) = gl::vao::create( gl ) else { return };
 
             gl.bind_vertex_array( Some( &vao ) );
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -67,14 +67,17 @@ mod private
     }
 
     /// Draw a single sprite as a textured quad (triangle strip, 4 vertices from `gl_VertexID`).
-    fn draw( &self, gl : &gl::GL, transform : &[ f32; 9 ], uv_rect : &[ f32; 4 ], sprite_size : &[ f32; 2 ], tint : &[ f32; 4 ], viewport : &[ f32; 2 ], depth : f32, max_depth : f32 )
+    ///
+    /// `region` is the sprite rect in pixels and `tex_size` is the sheet's dimensions — same
+    /// convention as `sprite_batch.vert`, so both shaders normalize UV the same way.
+    fn draw( &self, gl : &gl::GL, transform : &[ f32; 9 ], region : &[ f32; 4 ], tex_size : &[ f32; 2 ], tint : &[ f32; 4 ], viewport : &[ f32; 2 ], depth : f32, max_depth : f32 )
     {
       // Unbind any VAO to prevent stale attribute state from interfering
       gl.bind_vertex_array( None );
       self.program.activate();
       self.program.uniform_matrix_upload( "u_transform", transform.as_slice(), true );
-      self.program.uniform_upload( "u_uv_rect", uv_rect );
-      self.program.uniform_upload( "u_sprite_size", sprite_size );
+      self.program.uniform_upload( "u_region", region );
+      self.program.uniform_upload( "u_tex_size", tex_size );
       self.program.uniform_upload( "u_tint", tint );
       self.program.uniform_upload( "u_viewport", viewport );
       self.program.uniform_upload( "u_depth", &depth );
@@ -386,15 +389,11 @@ mod private
       self.gl.active_texture( gl::TEXTURE0 );
       self.gl.bind_texture( gl::TEXTURE_2D, Some( &gpu_tex.texture ) );
 
-      let [ rx, ry, rw, rh ] = gpu_sprite.region;
-      let tw = tw as f32;
-      let th = th as f32;
-      let uv_rect = [ rx / tw, ry / th, rw / tw, rh / th ];
-      let sprite_size = [ rw, rh ];
+      let tex_size = [ tw as f32, th as f32 ];
 
       let mat = s.transform.to_mat3();
       apply_blend( &self.gl, &s.blend );
-      self.sprite.draw( &self.gl, &mat, &uv_rect, &sprite_size, &s.tint, viewport, s.transform.depth, self.config.max_depth );
+      self.sprite.draw( &self.gl, &mat, &gpu_sprite.region, &tex_size, &s.tint, viewport, s.transform.depth, self.config.max_depth );
     }
 
     fn cmd_create_sprite_batch( &mut self, cmd : &CreateSpriteBatch ) -> Result< (), RenderError >

--- a/module/helper/tilemap_renderer/src/adapters/webgl.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl.rs
@@ -1640,9 +1640,15 @@ mod private
           RenderCommand::DrawBatch( db ) => self.cmd_draw_batch( db, &viewport )?,
           RenderCommand::DeleteBatch( db ) => self.cmd_delete_batch( db ),
 
-          // Path — skip (TODO)
-          RenderCommand::BeginPath( _ )
-          | RenderCommand::MoveTo( _ )
+          // Path — skip (TODO). Warn on the opener only (not MoveTo/LineTo/etc.)
+          // so a 1000-segment path produces one message, not 1000. `capabilities()`
+          // already advertises `paths: false`; this is a DX nudge for callers who
+          // submitted anyway.
+          RenderCommand::BeginPath( _ ) => web_sys::console::warn_1
+          (
+            &"WebGlBackend: path commands are not implemented; BeginPath..EndPath will be ignored (see capabilities().paths)".into()
+          ),
+          RenderCommand::MoveTo( _ )
           | RenderCommand::LineTo( _ )
           | RenderCommand::QuadTo( _ )
           | RenderCommand::CubicTo( _ )
@@ -1650,14 +1656,20 @@ mod private
           | RenderCommand::ClosePath( _ )
           | RenderCommand::EndPath( _ ) => {}
 
-          // Text — skip (TODO)
-          RenderCommand::BeginText( _ )
-          | RenderCommand::Char( _ )
+          // Text — skip (TODO). See note above re: opener-only warning.
+          RenderCommand::BeginText( _ ) => web_sys::console::warn_1
+          (
+            &"WebGlBackend: text commands are not implemented; BeginText..EndText will be ignored (see capabilities().text)".into()
+          ),
+          RenderCommand::Char( _ )
           | RenderCommand::EndText( _ ) => {}
 
-          // Grouping — skip (TODO)
-          RenderCommand::BeginGroup( _ )
-          | RenderCommand::EndGroup( _ ) => {}
+          // Grouping — skip (TODO).
+          RenderCommand::BeginGroup( _ ) => web_sys::console::warn_1
+          (
+            &"WebGlBackend: group commands are not implemented; BeginGroup..EndGroup will be ignored (see capabilities().effects)".into()
+          ),
+          RenderCommand::EndGroup( _ ) => {}
         }
       }
 

--- a/module/helper/tilemap_renderer/src/adapters/webgl/webgl_helpers.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl/webgl_helpers.rs
@@ -1,0 +1,713 @@
+//! WebGL adapter helpers.
+//!
+//! Extracted from `webgl.rs` to keep that file under the per-source-file size
+//! budget. Contains self-contained types, POD instance data, and pure
+//! mapping/setup helpers with no dependency on `WebGlBackend` internals.
+
+mod private
+{
+  use core::cell::Cell;
+  use core::marker::PhantomData;
+  use minwebgl as gl;
+  use nohash_hasher::IntMap;
+  use crate::backend::RenderError;
+  use crate::commands::{ SpriteBatchParams, MeshBatchParams };
+  use crate::types::{ asset, Batch, BlendMode, ResourceId, SamplerFilter, MipmapMode, Topology };
+
+  // ============================================================================
+  // ArrayBuffer — GPU-side Vec<T>
+  // ============================================================================
+
+  /// GPU array buffer with `Vec`-like semantics.
+  ///
+  /// Stores elements of type `T` in a WebGL `ARRAY_BUFFER`.
+  /// Tracks length and capacity; grows by 2× when full using
+  /// `copy_buffer_sub_data` (GPU-to-GPU copy into a freshly allocated buffer).
+  /// `swap_remove` uses a persistent one-element scratch buffer as an intermediary
+  /// to avoid the WebGL2 spec violation of binding the same buffer to both
+  /// `COPY_READ_BUFFER` and `COPY_WRITE_BUFFER` simultaneously.
+  pub struct ArrayBuffer< T >
+  {
+    gl : gl::GL,
+    buffer : web_sys::WebGlBuffer,
+    /// One-element scratch buffer used by `swap_remove` as a GPU-side intermediary.
+    scratch : web_sys::WebGlBuffer,
+    len : u32,
+    capacity : u32,
+    _marker : PhantomData< T >,
+  }
+
+  impl< T : gl::AsBytes > ArrayBuffer< T >
+  {
+    /// Creates a new GPU array buffer with the given initial capacity (in elements).
+    ///
+    /// Allocates two GPU buffers: the main data buffer (`capacity * stride` bytes)
+    /// and a one-element scratch buffer (`stride` bytes) used by `swap_remove`.
+    ///
+    /// # Errors
+    /// Returns `WebglError` if any GPU buffer cannot be created, or if
+    /// `capacity * stride` overflows `i32` (WebGL buffer size limit).
+    pub fn new( gl : &gl::GL, capacity : u32 ) -> Result< Self, gl::WebglError >
+    {
+      let buffer = gl::buffer::create( gl )?;
+      let byte_size = capacity
+        .checked_mul( Self::stride() )
+        .and_then( | n | i32::try_from( n ).ok() )
+        .ok_or( gl::WebglError::FailedToAllocateResource( "Buffer" ) )?;
+      gl.bind_buffer( gl::ARRAY_BUFFER, Some( &buffer ) );
+      gl.buffer_data_with_i32( gl::ARRAY_BUFFER, byte_size, gl::DYNAMIC_DRAW );
+      gl.bind_buffer( gl::ARRAY_BUFFER, None );
+
+      let scratch = gl::buffer::create( gl )?;
+      gl.bind_buffer( gl::ARRAY_BUFFER, Some( &scratch ) );
+      gl.buffer_data_with_i32( gl::ARRAY_BUFFER, Self::stride() as i32, gl::DYNAMIC_DRAW );
+      gl.bind_buffer( gl::ARRAY_BUFFER, None );
+
+      Ok( Self { gl : gl.clone(), buffer, scratch, len : 0, capacity, _marker : PhantomData } )
+    }
+
+    /// Byte size of one element.
+    fn stride() -> u32
+    {
+      core::mem::size_of::< T >() as u32
+    }
+
+    /// Number of elements currently stored.
+    #[ must_use ]
+    pub fn len( &self ) -> u32 { self.len }
+
+    /// Whether the buffer is empty.
+    #[ must_use ]
+    pub fn is_empty( &self ) -> bool { self.len == 0 }
+
+    /// Returns a reference to the underlying `WebGlBuffer`.
+    #[ must_use ]
+    pub fn buffer( &self ) -> &web_sys::WebGlBuffer { &self.buffer }
+
+    /// Appends an element at the end, growing if necessary.
+    ///
+    /// # Errors
+    /// Returns `WebglError` if the GPU buffer needs to grow and allocation fails.
+    pub fn push( &mut self, value : &T ) -> Result< (), gl::WebglError >
+    {
+      if self.len >= self.capacity
+      {
+        self.grow()?;
+      }
+      let offset = self.len * Self::stride();
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &self.buffer ) );
+      self.gl.buffer_sub_data_with_i32_and_u8_array( gl::ARRAY_BUFFER, offset as i32, value.as_bytes() );
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
+      self.len += 1;
+      Ok( () )
+    }
+
+    /// Updates the element at `index` in-place.
+    ///
+    /// # Panics
+    /// Panics if `index >= len`.
+    pub fn set( &self, index : u32, value : &T )
+    {
+      assert!( index < self.len, "ArrayBuffer::set index out of bounds" );
+      let offset = index * Self::stride();
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &self.buffer ) );
+      self.gl.buffer_sub_data_with_i32_and_u8_array( gl::ARRAY_BUFFER, offset as i32, value.as_bytes() );
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
+    }
+
+    /// Removes the element at `index` by swapping with the last element.
+    /// Returns the new length.
+    ///
+    /// # Panics
+    /// Panics if `index >= len`.
+    pub fn swap_remove( &mut self, index : u32 ) -> u32
+    {
+      assert!( index < self.len, "ArrayBuffer::swap_remove index out of bounds" );
+      self.len -= 1;
+      if index < self.len
+      {
+        let stride = Self::stride() as i32;
+        let src_offset = self.len as i32 * stride;
+        let dst_offset = index as i32 * stride;
+
+        // Binding the same buffer to both COPY_READ_BUFFER and COPY_WRITE_BUFFER is a
+        // WebGL2 spec violation (INVALID_OPERATION). Use a persistent one-element scratch
+        // buffer as an intermediary: last → scratch → removed slot. Both copies use
+        // distinct buffer objects, so the spec is satisfied and the copies are GPU-only.
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.buffer ) );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &self.scratch ) );
+        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
+        (
+          gl::COPY_READ_BUFFER,
+          gl::COPY_WRITE_BUFFER,
+          src_offset,
+          0,
+          stride,
+        );
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.scratch ) );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &self.buffer ) );
+        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
+        (
+          gl::COPY_READ_BUFFER,
+          gl::COPY_WRITE_BUFFER,
+          0,
+          dst_offset,
+          stride,
+        );
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, None );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, None );
+      }
+      self.len
+    }
+
+    /// Doubles the capacity, copying old data GPU-to-GPU.
+    fn grow( &mut self ) -> Result< (), gl::WebglError >
+    {
+      // saturating_mul avoids wrapping; the byte_size check below catches any overflow.
+      let new_capacity = self.capacity.saturating_mul( 2 ).max( 4 );
+      let new_byte_size = new_capacity
+        .checked_mul( Self::stride() )
+        .and_then( | n | i32::try_from( n ).ok() )
+        .ok_or( gl::WebglError::FailedToAllocateResource( "Buffer" ) )?;
+
+      let new_buffer = gl::buffer::create( &self.gl )?;
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, Some( &new_buffer ) );
+      self.gl.buffer_data_with_i32( gl::ARRAY_BUFFER, new_byte_size, gl::DYNAMIC_DRAW );
+      self.gl.bind_buffer( gl::ARRAY_BUFFER, None );
+
+      if self.len > 0
+      {
+        let copy_bytes = self.len * Self::stride();
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, Some( &self.buffer ) );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, Some( &new_buffer ) );
+        self.gl.copy_buffer_sub_data_with_i32_and_i32_and_i32
+        (
+          gl::COPY_READ_BUFFER,
+          gl::COPY_WRITE_BUFFER,
+          0,
+          0,
+          copy_bytes as i32,
+        );
+        self.gl.bind_buffer( gl::COPY_READ_BUFFER, None );
+        self.gl.bind_buffer( gl::COPY_WRITE_BUFFER, None );
+      }
+
+      self.gl.delete_buffer( Some( &self.buffer ) );
+      self.buffer = new_buffer;
+      self.capacity = new_capacity;
+      Ok( () )
+    }
+  }
+
+  impl< T > Drop for ArrayBuffer< T >
+  {
+    fn drop( &mut self )
+    {
+      self.gl.delete_buffer( Some( &self.buffer ) );
+      self.gl.delete_buffer( Some( &self.scratch ) );
+    }
+  }
+
+  // ============================================================================
+  // Instance data for batches
+  // ============================================================================
+
+  /// Per-instance data for sprite batches (18 floats = 72 bytes).
+  #[ repr( C ) ]
+  #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
+  pub struct SpriteInstanceData
+  {
+    /// Row-major 3×3 affine transform as 9 f32s (column-major layout on GPU).
+    pub transform : [ f32; 9 ],
+    /// Sub-rect in the source atlas: `[ u_min, v_min, u_max, v_max ]`.
+    pub region : [ f32; 4 ],
+    /// Per-instance tint multiplied into the sampled texel (premultiplied RGBA).
+    pub tint : [ f32; 4 ],
+    /// Depth value in `[0, 1]` used by the depth test.
+    pub depth : f32,
+  }
+
+  impl gl::AsBytes for SpriteInstanceData
+  {
+    fn as_bytes( &self ) -> &[ u8 ] { bytemuck::bytes_of( self ) }
+    fn len( &self ) -> usize { 1 }
+  }
+
+  /// Per-instance data for mesh batches (10 floats = 40 bytes).
+  #[ repr( C ) ]
+  #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
+  pub struct MeshInstanceData
+  {
+    /// Row-major 3×3 affine transform as 9 f32s (column-major layout on GPU).
+    pub transform : [ f32; 9 ],
+    /// Depth value in `[0, 1]` used by the depth test.
+    pub depth : f32,
+  }
+
+  impl gl::AsBytes for MeshInstanceData
+  {
+    fn as_bytes( &self ) -> &[ u8 ] { bytemuck::bytes_of( self ) }
+    fn len( &self ) -> usize { 1 }
+  }
+
+  // Compile-time layout assertions — GPU attrib setup depends on these exact sizes.
+  const _ : () = assert!( core::mem::size_of::< SpriteInstanceData >() == 72 ); // 18 floats × 4
+  const _ : () = assert!( core::mem::size_of::< MeshInstanceData >() == 40 ); // 10 floats × 4
+  const _ : () = assert!( core::mem::align_of::< SpriteInstanceData >() == 4 ); // f32 alignment
+  const _ : () = assert!( core::mem::align_of::< MeshInstanceData >() == 4 );
+
+  // ============================================================================
+  // GPU resource handles
+  // ============================================================================
+
+  /// Manages GPU-side resources: textures and geometry buffers.
+  #[ derive( Default ) ]
+  pub struct GpuResources
+  {
+    /// Texture cache keyed by image asset id.
+    pub textures : IntMap< ResourceId< asset::Image >, GpuTexture >,
+    /// Sprite cache keyed by sprite asset id.
+    pub sprites : IntMap< ResourceId< asset::Sprite >, GpuSprite >,
+    /// Geometry cache keyed by geometry asset id.
+    pub geometries : IntMap< ResourceId< asset::Geometry >, GpuGeometry >,
+    /// Active batches keyed by batch id.
+    pub batches : IntMap< ResourceId< Batch >, GpuBatch >,
+    /// Incremented on every `load_assets` call. In-flight `spawn_local` futures
+    /// from a previous cycle capture the old value and bail out on resolve,
+    /// so stale async data cannot overwrite freshly-loaded entries.
+    pub generation : u32,
+  }
+
+  impl GpuResources
+  {
+    /// Creates an empty resource cache.
+    #[ must_use ]
+    pub fn new() -> Self
+    {
+      Self::default()
+    }
+
+    /// Looks up a texture by image asset id.
+    #[ must_use ]
+    pub fn texture( &self, id : ResourceId< asset::Image > ) -> Option< &GpuTexture >
+    {
+      self.textures.get( &id )
+    }
+
+    /// Looks up a sprite by sprite asset id.
+    #[ must_use ]
+    pub fn sprite( &self, id : ResourceId< asset::Sprite > ) -> Option< &GpuSprite >
+    {
+      self.sprites.get( &id )
+    }
+
+    /// Looks up geometry by geometry asset id.
+    #[ must_use ]
+    pub fn geometry( &self, id : ResourceId< asset::Geometry > ) -> Option< &GpuGeometry >
+    {
+      self.geometries.get( &id )
+    }
+
+    /// Looks up a batch by batch id.
+    #[ must_use ]
+    pub fn batch( &self, id : ResourceId< Batch > ) -> Option< &GpuBatch >
+    {
+      self.batches.get( &id )
+    }
+
+    /// Mutable batch lookup (for instance add / set / remove operations).
+    pub fn batch_mut( &mut self, id : ResourceId< Batch > ) -> Option< &mut GpuBatch >
+    {
+      self.batches.get_mut( &id )
+    }
+
+    /// Inserts a texture into the cache.
+    pub fn store_texture( &mut self, id : ResourceId< asset::Image >, tex : GpuTexture )
+    {
+      self.textures.insert( id, tex );
+    }
+
+    /// Inserts a sprite into the cache.
+    pub fn store_sprite( &mut self, id : ResourceId< asset::Sprite >, sprite : GpuSprite )
+    {
+      self.sprites.insert( id, sprite );
+    }
+
+    /// Inserts geometry into the cache.
+    pub fn store_geometry( &mut self, id : ResourceId< asset::Geometry >, geom : GpuGeometry )
+    {
+      self.geometries.insert( id, geom );
+    }
+
+    /// Inserts a batch into the cache.
+    pub fn store_batch( &mut self, id : ResourceId< Batch >, batch : GpuBatch )
+    {
+      self.batches.insert( id, batch );
+    }
+  }
+
+  /// GPU-side texture handle plus cached natural size (filled once the image loads).
+  pub struct GpuTexture
+  {
+    /// GL context held for cleanup in `Drop`.
+    pub gl : gl::GL,
+    /// The underlying GL texture object.
+    pub texture : web_sys::WebGlTexture,
+    /// Natural width in pixels — populated when the async image load completes.
+    pub width : Cell< u32 >,
+    /// Natural height in pixels — populated when the async image load completes.
+    pub height : Cell< u32 >,
+    /// Sampler filter recorded at creation time; kept for parity with future re-applies.
+    pub filter : SamplerFilter,
+    /// Mipmap mode recorded at creation time; kept for parity with future re-applies.
+    pub mipmap : MipmapMode,
+  }
+
+  impl Drop for GpuTexture
+  {
+    fn drop( &mut self )
+    {
+      self.gl.delete_texture( Some( &self.texture ) );
+    }
+  }
+
+  /// Sprite lookup data: sheet reference + pixel region.
+  /// UV rect and size are computed at draw time from the sheet's dimensions.
+  pub struct GpuSprite
+  {
+    /// Sheet texture to bind.
+    pub sheet : ResourceId< asset::Image >,
+    /// Region within the sheet: `[x, y, w, h]` in pixels.
+    pub region : [ f32; 4 ],
+  }
+
+  /// GPU-side geometry: VAO plus the backing buffers.
+  pub struct GpuGeometry
+  {
+    /// GL context held for cleanup in `Drop`.
+    pub gl : gl::GL,
+    /// VAO pre-configured with position/uv/index attribs.
+    pub vao : web_sys::WebGlVertexArrayObject,
+    /// Position buffer (attrib 0). `None` if the geometry has no positions.
+    pub position_buffer : Option< web_sys::WebGlBuffer >,
+    /// UV buffer (attrib 1). `None` if the geometry has no UVs.
+    pub uv_buffer : Option< web_sys::WebGlBuffer >,
+    /// Index buffer. `None` if the geometry draws via `drawArrays`.
+    pub index_buffer : Option< web_sys::WebGlBuffer >,
+    /// Vertex count used when `index_count` is `None`.
+    pub vertex_count : u32,
+    /// Number of indices and the GL type constant (`UNSIGNED_BYTE` / `UNSIGNED_SHORT` / `UNSIGNED_INT`).
+    /// `None` if the geometry has no index buffer (draw with `drawArrays`).
+    pub index_count : Option< ( u32, u32 ) >,
+  }
+
+  impl Drop for GpuGeometry
+  {
+    fn drop( &mut self )
+    {
+      self.gl.delete_vertex_array( Some( &self.vao ) );
+      if let Some( ref buf ) = self.position_buffer { self.gl.delete_buffer( Some( buf ) ); }
+      if let Some( ref buf ) = self.uv_buffer { self.gl.delete_buffer( Some( buf ) ); }
+      if let Some( ref buf ) = self.index_buffer { self.gl.delete_buffer( Some( buf ) ); }
+    }
+  }
+
+  // ============================================================================
+  // GpuBatch — persistent instance buffer + VAO
+  // ============================================================================
+
+  /// Persistent batch — sprite or mesh.
+  pub enum GpuBatch
+  {
+    /// Sprite batch: sprite-instance buffer and the parameters that define the batch.
+    Sprite
+    {
+      /// GL context handle held for cleanup in `Drop`.
+      gl : gl::GL,
+      /// Per-instance sprite data (transform / region / tint / depth).
+      instances : ArrayBuffer< SpriteInstanceData >,
+      /// VAO holding the instance attrib bindings (locations 0–5).
+      vao : web_sys::WebGlVertexArrayObject,
+      /// Batch-wide parameters (atlas / blend).
+      params : SpriteBatchParams,
+    },
+    /// Mesh batch: mesh-instance buffer bound alongside a geometry's VBOs.
+    Mesh
+    {
+      /// GL context handle held for cleanup in `Drop`.
+      gl : gl::GL,
+      /// Per-instance mesh data (transform / depth).
+      instances : ArrayBuffer< MeshInstanceData >,
+      /// VAO holding geometry attribs (0–1) and instance attribs (2–5).
+      vao : web_sys::WebGlVertexArrayObject,
+      /// Batch-wide parameters (geometry / texture / blend).
+      params : MeshBatchParams,
+    },
+  }
+
+  impl Drop for GpuBatch
+  {
+    fn drop( &mut self )
+    {
+      match self
+      {
+        Self::Sprite { gl, vao, .. } | Self::Mesh { gl, vao, .. } =>
+          gl.delete_vertex_array( Some( vao ) ),
+      }
+    }
+  }
+
+  // ============================================================================
+  // VAO setup helpers
+  // ============================================================================
+
+  /// Binds instance attrib pointers for a sprite batch VAO.
+  pub fn setup_sprite_batch_vao( gl : &gl::GL, vao : &web_sys::WebGlVertexArrayObject, buffer : &web_sys::WebGlBuffer )
+  {
+    gl.bind_vertex_array( Some( vao ) );
+    gl.bind_buffer( gl::ARRAY_BUFFER, Some( buffer ) );
+
+    let stride = core::mem::size_of::< SpriteInstanceData >() as i32;
+
+    // transform: 3 × vec3 at locations 0, 1, 2
+    for i in 0..3_u32
+    {
+      gl.enable_vertex_attrib_array( i );
+      gl.vertex_attrib_pointer_with_i32( i, 3, gl::FLOAT, false, stride, ( i * 12 ) as i32 );
+      gl.vertex_attrib_divisor( i, 1 );
+    }
+    // region: vec4 at location 3, offset 36
+    gl.enable_vertex_attrib_array( 3 );
+    gl.vertex_attrib_pointer_with_i32( 3, 4, gl::FLOAT, false, stride, 36 );
+    gl.vertex_attrib_divisor( 3, 1 );
+    // tint: vec4 at location 4, offset 52
+    gl.enable_vertex_attrib_array( 4 );
+    gl.vertex_attrib_pointer_with_i32( 4, 4, gl::FLOAT, false, stride, 52 );
+    gl.vertex_attrib_divisor( 4, 1 );
+    // depth: float at location 5, offset 68
+    gl.enable_vertex_attrib_array( 5 );
+    gl.vertex_attrib_pointer_with_i32( 5, 1, gl::FLOAT, false, stride, 68 );
+    gl.vertex_attrib_divisor( 5, 1 );
+
+    gl.bind_vertex_array( None );
+  }
+
+  /// Sets up a mesh batch VAO with geometry attribs (0–1) and instance attribs (2–5).
+  ///
+  /// Takes the geometry buffers directly (position, uv, index) as `Option`s so this
+  /// helper stays decoupled from the adapter's internal `GpuGeometry` struct.
+  pub fn setup_mesh_batch_vao
+  (
+    gl : &gl::GL,
+    vao : &web_sys::WebGlVertexArrayObject,
+    position_buffer : Option< &web_sys::WebGlBuffer >,
+    uv_buffer : Option< &web_sys::WebGlBuffer >,
+    index_buffer : Option< &web_sys::WebGlBuffer >,
+    instance_buffer : &web_sys::WebGlBuffer,
+  )
+  {
+    gl.bind_vertex_array( Some( vao ) );
+
+    // Geometry: positions (attrib 0)
+    if let Some( buf ) = position_buffer
+    {
+      gl.bind_buffer( gl::ARRAY_BUFFER, Some( buf ) );
+      gl.enable_vertex_attrib_array( 0 );
+      gl.vertex_attrib_pointer_with_i32( 0, 2, gl::FLOAT, false, 0, 0 );
+    }
+
+    // Geometry: UVs (attrib 1)
+    if let Some( buf ) = uv_buffer
+    {
+      gl.bind_buffer( gl::ARRAY_BUFFER, Some( buf ) );
+      gl.enable_vertex_attrib_array( 1 );
+      gl.vertex_attrib_pointer_with_i32( 1, 2, gl::FLOAT, false, 0, 0 );
+    }
+
+    // Geometry: indices
+    if let Some( buf ) = index_buffer
+    {
+      gl.bind_buffer( gl::ELEMENT_ARRAY_BUFFER, Some( buf ) );
+    }
+
+    // Instance: transform 3 × vec3 at locations 2, 3, 4
+    gl.bind_buffer( gl::ARRAY_BUFFER, Some( instance_buffer ) );
+    let stride = core::mem::size_of::< MeshInstanceData >() as i32;
+    for i in 0..3_u32
+    {
+      let loc = i + 2;
+      gl.enable_vertex_attrib_array( loc );
+      gl.vertex_attrib_pointer_with_i32( loc, 3, gl::FLOAT, false, stride, ( i * 12 ) as i32 );
+      gl.vertex_attrib_divisor( loc, 1 );
+    }
+    // depth: float at location 5, offset 36
+    gl.enable_vertex_attrib_array( 5 );
+    gl.vertex_attrib_pointer_with_i32( 5, 1, gl::FLOAT, false, stride, 36 );
+    gl.vertex_attrib_divisor( 5, 1 );
+
+    gl.bind_vertex_array( None );
+  }
+
+  // ============================================================================
+  // Async load helpers
+  // ============================================================================
+
+  /// Data source that can be sent into a `spawn_local` future.
+  /// Clones the bytes (for `Bytes`) or the path string (for `Path`).
+  pub enum Loadable
+  {
+    /// Bytes are already in memory — no I/O needed.
+    Ready( Vec< u8 > ),
+    /// Path to fetch asynchronously via `gl::file::load`.
+    Fetch( String ),
+  }
+
+  /// Converts an `assets::Source` into an owned `Loadable` that can cross
+  /// an `async` boundary (clones bytes or paths).
+  #[ must_use ]
+  pub fn source_to_loadable( source : &crate::assets::Source ) -> Loadable
+  {
+    match source
+    {
+      crate::assets::Source::Bytes( bytes ) => Loadable::Ready( bytes.clone() ),
+      crate::assets::Source::Path( path ) => Loadable::Fetch( path.to_string_lossy().into_owned() ),
+    }
+  }
+
+  /// Resolves a `Loadable` to bytes — trivial pass-through for `Ready`,
+  /// or an async fetch for `Fetch`. Returns `None` on fetch failure.
+  pub async fn resolve_loadable( loadable : Loadable ) -> Option< Vec< u8 > >
+  {
+    match loadable
+    {
+      Loadable::Ready( bytes ) => Some( bytes ),
+      Loadable::Fetch( path ) => gl::file::load( &path ).await.ok(),
+    }
+  }
+
+  // ============================================================================
+  // Pure GL state / format mappers
+  // ============================================================================
+
+  /// Maps a `DataType` to `(bytes_per_index, gl_type_constant)` for `drawElements`.
+  ///
+  /// # Errors
+  /// Returns `Err` for `F32`, which is not a valid WebGL index type.
+  pub fn index_format( dt : &crate::assets::DataType ) -> Result< ( u32, u32 ), RenderError >
+  {
+    use crate::assets::DataType;
+    match dt
+    {
+      DataType::U8  => Ok( ( 1, gl::UNSIGNED_BYTE ) ),
+      DataType::U16 => Ok( ( 2, gl::UNSIGNED_SHORT ) ),
+      DataType::U32 => Ok( ( 4, gl::UNSIGNED_INT ) ),
+      DataType::F32 => Err( RenderError::BackendError
+      (
+        "GeometryAsset.data_type: F32 is not a valid index format; use U8, U16, or U32".into()
+      )),
+    }
+  }
+
+  /// Sets mag/min filter on the currently bound `TEXTURE_2D` based on `filter` and `mipmap`.
+  /// Caller is responsible for calling `generate_mipmap` separately when `mipmap != Off`
+  /// (after the level-0 upload completes — on the async path that's inside the `on_load` callback).
+  pub fn apply_texture_filter( gl : &gl::GL, filter : &SamplerFilter, mipmap : &MipmapMode )
+  {
+    // mag_filter ignores mipmaps — magnification samples only level 0.
+    let mag = match filter
+    {
+      SamplerFilter::Nearest => gl::NEAREST,
+      SamplerFilter::Linear => gl::LINEAR,
+    };
+    // min_filter combines within-level interpolation with between-level interpolation.
+    let min = match ( filter, mipmap )
+    {
+      ( SamplerFilter::Nearest, MipmapMode::Off )     => gl::NEAREST,
+      ( SamplerFilter::Linear,  MipmapMode::Off )     => gl::LINEAR,
+      ( SamplerFilter::Nearest, MipmapMode::Nearest ) => gl::NEAREST_MIPMAP_NEAREST,
+      ( SamplerFilter::Linear,  MipmapMode::Nearest ) => gl::LINEAR_MIPMAP_NEAREST,
+      ( SamplerFilter::Nearest, MipmapMode::Linear )  => gl::NEAREST_MIPMAP_LINEAR,
+      ( SamplerFilter::Linear,  MipmapMode::Linear )  => gl::LINEAR_MIPMAP_LINEAR,
+    };
+    gl.tex_parameteri( gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, mag as i32 );
+    gl.tex_parameteri( gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, min as i32 );
+  }
+
+  /// Programs the GL blend function for a given `BlendMode`.
+  ///
+  /// Alpha factors are always `(ONE, ONE_MINUS_SRC_ALPHA)` so the framebuffer
+  /// alpha follows Porter-Duff "over": `a = src_a + dst_a * (1 - src_a)`. Using
+  /// the RGB factors on the alpha channel would produce wrong framebuffer alpha
+  /// (e.g. `src_a^2` under `Normal`) and break readPixels / compositing onto a
+  /// transparent canvas background.
+  pub fn apply_blend( gl : &gl::GL, blend : &BlendMode )
+  {
+    match blend
+    {
+      // Color: src + dst. Alpha: standard over.
+      BlendMode::Add => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
+      // Approximation: diverges from Photoshop Multiply when src_alpha < 1 — the
+      // DST_COLOR factor multiplies dst by raw src.rgb (not src.rgb*src_a), so
+      // partially transparent sources darken the destination more than the
+      // reference formula prescribes. Exact only when src_alpha = 1.
+      // qqq(FBO): replace with Photoshop-accurate formula — see BlendMode::Multiply doc.
+      // Color: src*dst + dst*(1-src_a). Alpha: standard over.
+      BlendMode::Multiply => gl.blend_func_separate( gl::DST_COLOR, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
+      // Same class of approximation as Multiply: the ONE / ONE_MINUS_SRC_COLOR
+      // factors use raw src.rgb, so a partially transparent source still
+      // contributes its full (unmultiplied) color. Exact only when src_alpha = 1
+      // or when the source is premultiplied.
+      // Color: src + dst*(1-src). Alpha: standard over.
+      BlendMode::Screen => gl.blend_func_separate( gl::ONE, gl::ONE_MINUS_SRC_COLOR, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
+      // qqq: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
+      // expressed as a single blend_func call — it requires a custom shader or a
+      // separate FBO read-back pass, neither of which is implemented yet.
+      // Overlay falls back to Normal so rendering is at least visible; the
+      // console.warn below makes the silent substitution observable.
+      BlendMode::Overlay =>
+      {
+        web_sys::console::warn_1
+        (
+          &"BlendMode::Overlay is not supported in WebGL2 without an FBO pass; falling back to Normal".into()
+        );
+        gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA );
+      }
+      // Color: src*src_a + dst*(1-src_a). Alpha: standard over.
+      BlendMode::Normal => gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA ),
+    }
+  }
+
+  /// Maps a `Topology` to the corresponding WebGL primitive constant.
+  #[ must_use ]
+  pub fn topology_to_gl( t : &Topology ) -> u32
+  {
+    match t
+    {
+      Topology::TriangleList => gl::TRIANGLES,
+      Topology::TriangleStrip => gl::TRIANGLE_STRIP,
+      Topology::LineList => gl::LINES,
+      Topology::LineStrip => gl::LINE_STRIP,
+    }
+  }
+}
+
+mod_interface::mod_interface!
+{
+  own use ArrayBuffer;
+  own use SpriteInstanceData;
+  own use MeshInstanceData;
+  own use GpuResources;
+  own use GpuTexture;
+  own use GpuSprite;
+  own use GpuGeometry;
+  own use GpuBatch;
+  own use setup_sprite_batch_vao;
+  own use setup_mesh_batch_vao;
+  own use apply_blend;
+  own use Loadable;
+  own use source_to_loadable;
+  own use resolve_loadable;
+  own use index_format;
+  own use apply_texture_filter;
+  own use topology_to_gl;
+}

--- a/module/helper/tilemap_renderer/src/adapters/webgl/webgl_helpers.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl/webgl_helpers.rs
@@ -220,11 +220,14 @@ mod private
   {
     /// Row-major 3×3 affine transform as 9 f32s (column-major layout on GPU).
     pub transform : [ f32; 9 ],
-    /// Sub-rect in the source atlas: `[ u_min, v_min, u_max, v_max ]`.
+    /// Sub-rect in the source sheet: `[ x, y, w, h ]` in pixels. The shader
+    /// divides by `u_tex_size` to produce the sampled UV.
     pub region : [ f32; 4 ],
     /// Per-instance tint multiplied into the sampled texel (premultiplied RGBA).
     pub tint : [ f32; 4 ],
-    /// Depth value in `[0, 1]` used by the depth test.
+    /// Raw `Transform::depth` value; the shader maps it into clip-space `z`
+    /// by dividing by `RenderConfig::max_depth`. See `Transform::depth` for
+    /// the valid range.
     pub depth : f32,
   }
 
@@ -241,7 +244,9 @@ mod private
   {
     /// Row-major 3×3 affine transform as 9 f32s (column-major layout on GPU).
     pub transform : [ f32; 9 ],
-    /// Depth value in `[0, 1]` used by the depth test.
+    /// Raw `Transform::depth` value; the shader maps it into clip-space `z`
+    /// by dividing by `RenderConfig::max_depth`. See `Transform::depth` for
+    /// the valid range.
     pub depth : f32,
     /// Per-instance tint, multiplied into the fragment color alongside
     /// `MeshBatchParams::fill` (and any sampled texture).

--- a/module/helper/tilemap_renderer/src/adapters/webgl/webgl_helpers.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl/webgl_helpers.rs
@@ -8,6 +8,7 @@ mod private
 {
   use core::cell::Cell;
   use core::marker::PhantomData;
+  use core::sync::atomic::{ AtomicBool, Ordering };
   use minwebgl as gl;
   use nohash_hasher::IntMap;
   use crate::backend::RenderError;
@@ -669,14 +670,20 @@ mod private
       // qqq: true Overlay (Multiply where dst<0.5, Screen where dst>0.5) cannot be
       // expressed as a single blend_func call — it requires a custom shader or a
       // separate FBO read-back pass, neither of which is implemented yet.
-      // Overlay falls back to Normal so rendering is at least visible; the
-      // console.warn below makes the silent substitution observable.
+      // Overlay falls back to Normal so rendering is at least visible; the warn
+      // below is emitted at most once per process because the limitation is
+      // static (not a per-draw condition) — calling it every frame from a
+      // submit() loop would flood the console without adding information.
       BlendMode::Overlay =>
       {
-        web_sys::console::warn_1
-        (
-          &"BlendMode::Overlay is not supported in WebGL2 without an FBO pass; falling back to Normal".into()
-        );
+        static OVERLAY_WARNED : AtomicBool = AtomicBool::new( false );
+        if !OVERLAY_WARNED.swap( true, Ordering::Relaxed )
+        {
+          web_sys::console::warn_1
+          (
+            &"BlendMode::Overlay is not supported in WebGL2 without an FBO pass; falling back to Normal".into()
+          );
+        }
         gl.blend_func_separate( gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA );
       }
       // Color: src*src_a + dst*(1-src_a). Alpha: standard over.

--- a/module/helper/tilemap_renderer/src/adapters/webgl/webgl_helpers.rs
+++ b/module/helper/tilemap_renderer/src/adapters/webgl/webgl_helpers.rs
@@ -233,7 +233,7 @@ mod private
     fn len( &self ) -> usize { 1 }
   }
 
-  /// Per-instance data for mesh batches (10 floats = 40 bytes).
+  /// Per-instance data for mesh batches (14 floats = 56 bytes).
   #[ repr( C ) ]
   #[ derive( Clone, Copy, bytemuck::Zeroable, bytemuck::Pod ) ]
   pub struct MeshInstanceData
@@ -242,6 +242,9 @@ mod private
     pub transform : [ f32; 9 ],
     /// Depth value in `[0, 1]` used by the depth test.
     pub depth : f32,
+    /// Per-instance tint, multiplied into the fragment color alongside
+    /// `MeshBatchParams::fill` (and any sampled texture).
+    pub tint : [ f32; 4 ],
   }
 
   impl gl::AsBytes for MeshInstanceData
@@ -252,7 +255,7 @@ mod private
 
   // Compile-time layout assertions — GPU attrib setup depends on these exact sizes.
   const _ : () = assert!( core::mem::size_of::< SpriteInstanceData >() == 72 ); // 18 floats × 4
-  const _ : () = assert!( core::mem::size_of::< MeshInstanceData >() == 40 ); // 10 floats × 4
+  const _ : () = assert!( core::mem::size_of::< MeshInstanceData >() == 56 ); // 14 floats × 4
   const _ : () = assert!( core::mem::align_of::< SpriteInstanceData >() == 4 ); // f32 alignment
   const _ : () = assert!( core::mem::align_of::< MeshInstanceData >() == 4 );
 
@@ -544,6 +547,10 @@ mod private
     gl.enable_vertex_attrib_array( 5 );
     gl.vertex_attrib_pointer_with_i32( 5, 1, gl::FLOAT, false, stride, 36 );
     gl.vertex_attrib_divisor( 5, 1 );
+    // tint: vec4 at location 6, offset 40
+    gl.enable_vertex_attrib_array( 6 );
+    gl.vertex_attrib_pointer_with_i32( 6, 4, gl::FLOAT, false, stride, 40 );
+    gl.vertex_attrib_divisor( 6, 1 );
 
     gl.bind_vertex_array( None );
   }

--- a/module/helper/tilemap_renderer/src/assets.rs
+++ b/module/helper/tilemap_renderer/src/assets.rs
@@ -8,7 +8,7 @@ mod private
 {
   use std::path::PathBuf;
   use nohash_hasher::IntSet;
-  use crate::types::{ ResourceId, SamplerFilter, asset };
+  use crate::types::{ ResourceId, SamplerFilter, MipmapMode, asset };
 
   // ============================================================================
   // Asset container
@@ -182,6 +182,9 @@ mod private
     /// SVG: `image-rendering: pixelated` (Nearest) vs `auto` (Linear).
     /// GPU: sampler mag/min filter.
     pub filter : SamplerFilter,
+    /// Mipmap generation and between-level interpolation. GPU backends honor this
+    /// and call `generateMipmap` at load time; SVG backends ignore it. Defaults to `Off`.
+    pub mipmap : MipmapMode,
   }
 
   /// A rectangular region within a loaded image (sprite sheet support).

--- a/module/helper/tilemap_renderer/src/assets.rs
+++ b/module/helper/tilemap_renderer/src/assets.rs
@@ -372,8 +372,17 @@ mod private
   pub enum ImageSource
   {
     /// Path to image file — backend decodes (PNG, JPEG, etc.).
+    ///
+    /// WebGL backend: the image is fetched and uploaded asynchronously via an
+    /// `HtmlImageElement`. If loading fails (file not found, CORS, decode error),
+    /// the error is logged to `console.error` and the texture remains empty;
+    /// it cannot be propagated back through `load_assets` because the failure
+    /// happens after that call returns.
     Path( PathBuf ),
     /// Encoded image in memory (PNG, JPEG, etc.) — backend decodes.
+    ///
+    /// **Not yet implemented in the WebGL backend** — this variant is silently
+    /// skipped during `load_assets`. Use `Bitmap` (pre-decoded) or `Path` instead.
     Encoded( Vec< u8 > ),
     /// Raw pixel data — ready to upload directly.
     Bitmap
@@ -414,16 +423,20 @@ mod private
   }
 
   /// Primitive data type for geometry buffers.
+  ///
+  /// When used as [`GeometryAsset::data_type`] (index buffer element type),
+  /// only `U8`, `U16`, and `U32` are valid. `F32` is rejected by the WebGL
+  /// backend with `RenderError::BackendError` during `load_assets`.
   #[ derive( Debug ) ]
   pub enum DataType
   {
-    /// Unsigned 8-bit integer.
+    /// Unsigned 8-bit integer. Valid as an index type (`UNSIGNED_BYTE`).
     U8,
-    /// Unsigned 16-bit integer.
+    /// Unsigned 16-bit integer. Valid as an index type (`UNSIGNED_SHORT`).
     U16,
-    /// Unsigned 32-bit integer.
+    /// Unsigned 32-bit integer. Valid as an index type (`UNSIGNED_INT`).
     U32,
-    /// 32-bit floating point.
+    /// 32-bit floating point. Valid for position/UV buffers; **not** valid as an index type.
     F32,
   }
 

--- a/module/helper/tilemap_renderer/src/assets.rs
+++ b/module/helper/tilemap_renderer/src/assets.rs
@@ -212,7 +212,10 @@ mod private
     pub uvs : Option< Source >,
     /// Optional vertex indices for indexed drawing.
     pub indices : Option< Source >,
-    /// Primitive data type for index/position buffers.
+    /// Element type of the index buffer. Must be `U8`, `U16`, or `U32`.
+    /// `F32` is not a valid index type and will be rejected by the WebGL backend at load time.
+    ///
+    /// Ignored when `indices` is `None`.
     pub data_type : DataType,
   }
 

--- a/module/helper/tilemap_renderer/src/backend.rs
+++ b/module/helper/tilemap_renderer/src/backend.rs
@@ -7,6 +7,7 @@ mod private
 {
   use crate::commands::RenderCommand;
   use crate::assets::Assets;
+  use crate::types::BlendMode;
   use error_tools::Error;
 
   // ============================================================================
@@ -98,8 +99,15 @@ mod private
     pub clip_masks : bool,
     /// Supports visual effects.
     pub effects : bool,
-    /// Supports blend modes.
+    /// Supports **all** [`BlendMode`] variants correctly. `false` means at least
+    /// one variant falls back / is unsupported — check [`Self::supported_blend_modes`]
+    /// for the precise set before submitting a specific mode.
     pub blend_modes : bool,
+    /// The exact set of [`BlendMode`] variants that render correctly on this
+    /// backend. Variants not listed here either fall back silently (e.g. WebGL
+    /// Overlay → Normal) or are fully unsupported. Empty slice means no
+    /// blending at all (e.g. terminal backend).
+    pub supported_blend_modes : &'static [ BlendMode ],
     /// Supports text on a path.
     pub text_on_path : bool,
     /// Maximum texture/image dimension. 0 = unlimited (e.g. SVG).

--- a/module/helper/tilemap_renderer/src/backend.rs
+++ b/module/helper/tilemap_renderer/src/backend.rs
@@ -129,10 +129,16 @@ mod private
   pub trait Backend
   {
     /// Upload / prepare assets for this backend.
-    /// Called once (or when assets change).
+    /// Safe to call multiple times (e.g. on level transitions).
     ///
-    /// - SVG: generates `<defs>` (symbols, gradients, patterns, clipPaths)
-    /// - GPU: uploads textures, creates samplers, builds vertex buffers
+    /// **Each call replaces all previously loaded assets.** Backends must
+    /// clear and reload all GPU/SVG state — including any active batches.
+    /// After `load_assets` returns, all [`ResourceId`]s from the previous
+    /// call are invalid; any batches created before this call are destroyed.
+    ///
+    /// - SVG: regenerates `<defs>` (symbols, gradients, patterns, clipPaths)
+    /// - GPU (WebGL): re-uploads textures, rebuilds vertex buffers, clears all batches
+    ///   (VAOs and instance buffers are released via `GpuBatch::drop`)
     ///
     /// # Errors
     ///

--- a/module/helper/tilemap_renderer/src/commands.rs
+++ b/module/helper/tilemap_renderer/src/commands.rs
@@ -231,10 +231,9 @@ mod private
     /// Parent transform applied to all instances.
     ///
     /// The effective depth for each instance is `transform.depth +
-    /// instance_transform.depth`. Keep the sum in `[-max_depth, max_depth]`
-    /// (see `RenderConfig::max_depth`) for correct ordering — the WebGL
-    /// backend clamps out-of-range sums to avoid silent clipping, but
-    /// clamped instances lose their relative ordering.
+    /// instance_transform.depth`. The **sum** must stay in
+    /// `[-max_depth, max_depth]` (see `RenderConfig::max_depth`); the GPU
+    /// clips instances whose sum falls outside that range.
     pub transform : Transform,
     /// The sprite sheet image. All instances must reference sprites from this sheet.
     pub sheet : ResourceId< asset::Image >,
@@ -251,10 +250,9 @@ mod private
     /// Parent transform applied to all instances.
     ///
     /// The effective depth for each instance is `transform.depth +
-    /// instance_transform.depth`. Keep the sum in `[-max_depth, max_depth]`
-    /// (see `RenderConfig::max_depth`) for correct ordering — the WebGL
-    /// backend clamps out-of-range sums to avoid silent clipping, but
-    /// clamped instances lose their relative ordering.
+    /// instance_transform.depth`. The **sum** must stay in
+    /// `[-max_depth, max_depth]` (see `RenderConfig::max_depth`); the GPU
+    /// clips instances whose sum falls outside that range.
     pub transform : Transform,
     /// Geometry resource.
     pub geometry : ResourceId< asset::Geometry >,

--- a/module/helper/tilemap_renderer/src/commands.rs
+++ b/module/helper/tilemap_renderer/src/commands.rs
@@ -279,7 +279,24 @@ mod private
   }
 
   /// Binds a batch for editing. All subsequent instance commands
+  /// (`AddSpriteInstance`, `SetSpriteInstance`, `RemoveInstance`, etc.)
   /// apply to this batch until `UnbindBatch`.
+  ///
+  /// # Invariants
+  ///
+  /// - Only **one** batch can be bound at a time. Issuing `BindBatch` while
+  ///   another batch is already bound is a protocol error; the WebGL backend
+  ///   returns `RenderError::BackendError`.
+  /// - Always pair every `BindBatch` with a matching `UnbindBatch` before
+  ///   issuing `DrawBatch` or a second `BindBatch`.
+  ///
+  /// **Correct lifecycle:**
+  /// ```ignore
+  /// BindBatch(id)
+  /// Add/Set/RemoveInstance …
+  /// UnbindBatch          // commits VAO state; safe to draw after this
+  /// DrawBatch(id)
+  /// ```
   #[ derive( Debug, Clone, Copy ) ]
   pub struct BindBatch
   {
@@ -370,12 +387,31 @@ mod private
     pub params : MeshBatchParams,
   }
 
-  /// Unbinds the batch and applies all pending changes.
+  /// Unbinds the current batch and commits all pending instance changes.
+  ///
+  /// In the WebGL backend, `UnbindBatch` re-configures the batch's VAO with
+  /// the current instance buffer. This step is **required** if any `AddInstance`
+  /// calls caused the internal buffer to grow (reallocate), because a grow
+  /// replaces the underlying `WebGlBuffer` and invalidates the previous VAO
+  /// attribute pointers.
+  ///
+  /// Calling `UnbindBatch` when no batch is bound is a no-op.
   #[ derive( Debug, Clone, Copy ) ]
   pub struct UnbindBatch;
 
   /// Draws a previously created batch (sprite or mesh).
   /// GPU: single instanced draw call.
+  ///
+  /// # Invariants
+  ///
+  /// The batch must **not** be bound at the time of this command. Calling
+  /// `DrawBatch` while the batch is still bound (i.e. without a preceding
+  /// `UnbindBatch`) is a protocol error; the WebGL backend returns
+  /// `RenderError::BackendError`.
+  ///
+  /// This restriction exists because `UnbindBatch` is responsible for
+  /// refreshing the VAO when the instance buffer grew during recording.
+  /// Drawing with a stale VAO produces undefined GPU behavior.
   #[ derive( Debug, Clone, Copy ) ]
   pub struct DrawBatch
   {
@@ -383,7 +419,13 @@ mod private
     pub batch : ResourceId< Batch >,
   }
 
-  /// Deletes a batch and frees its resources.
+  /// Deletes a batch and frees its GPU resources.
+  ///
+  /// If the batch is currently bound when this command is processed, the
+  /// WebGL backend implicitly clears the binding (equivalent to `UnbindBatch`
+  /// without a VAO refresh, since the batch is about to be destroyed).
+  /// Subsequent instance commands that would have targeted this batch become
+  /// no-ops.
   #[ derive( Debug, Clone, Copy ) ]
   pub struct DeleteBatch
   {

--- a/module/helper/tilemap_renderer/src/commands.rs
+++ b/module/helper/tilemap_renderer/src/commands.rs
@@ -229,6 +229,12 @@ mod private
   pub struct SpriteBatchParams
   {
     /// Parent transform applied to all instances.
+    ///
+    /// The effective depth for each instance is `transform.depth +
+    /// instance_transform.depth`. Keep the sum in `[-max_depth, max_depth]`
+    /// (see `RenderConfig::max_depth`) for correct ordering — the WebGL
+    /// backend clamps out-of-range sums to avoid silent clipping, but
+    /// clamped instances lose their relative ordering.
     pub transform : Transform,
     /// The sprite sheet image. All instances must reference sprites from this sheet.
     pub sheet : ResourceId< asset::Image >,
@@ -243,6 +249,12 @@ mod private
   pub struct MeshBatchParams
   {
     /// Parent transform applied to all instances.
+    ///
+    /// The effective depth for each instance is `transform.depth +
+    /// instance_transform.depth`. Keep the sum in `[-max_depth, max_depth]`
+    /// (see `RenderConfig::max_depth`) for correct ordering — the WebGL
+    /// backend clamps out-of-range sums to avoid silent clipping, but
+    /// clamped instances lose their relative ordering.
     pub transform : Transform,
     /// Geometry resource.
     pub geometry : ResourceId< asset::Geometry >,

--- a/module/helper/tilemap_renderer/src/commands.rs
+++ b/module/helper/tilemap_renderer/src/commands.rs
@@ -256,7 +256,10 @@ mod private
     pub transform : Transform,
     /// Geometry resource.
     pub geometry : ResourceId< asset::Geometry >,
-    /// Fill style.
+    /// Batch-level fill style. The final fragment color is
+    /// `fill * instance.tint` (times the sampled texel when `texture` is set),
+    /// so per-instance `AddMeshInstance::tint` / `SetMeshInstance::tint`
+    /// modulate this batch-wide color independently.
     pub fill : FillRef,
     /// Optional texture.
     pub texture : Option< ResourceId< asset::Image > >,
@@ -342,6 +345,10 @@ mod private
   {
     /// Instance transform.
     pub transform : Transform,
+    /// Per-instance tint multiplied into the fragment color alongside
+    /// `MeshBatchParams::fill` (and any sampled texture). Use `[1.0; 4]`
+    /// when no per-instance coloring is needed.
+    pub tint : [ f32; 4 ],
   }
 
   /// Updates a sprite instance at `index` within the bound batch.
@@ -378,6 +385,10 @@ mod private
     pub index : u32,
     /// Updated transform.
     pub transform : Transform,
+    /// Per-instance tint multiplied into the fragment color alongside
+    /// `MeshBatchParams::fill` (and any sampled texture). Use `[1.0; 4]`
+    /// when no per-instance coloring is needed.
+    pub tint : [ f32; 4 ],
   }
 
   /// Removes an instance at `index` from the bound batch using **swap-remove**.

--- a/module/helper/tilemap_renderer/src/commands.rs
+++ b/module/helper/tilemap_renderer/src/commands.rs
@@ -220,6 +220,8 @@ mod private
   /// // Update later
   /// cmd( BindBatch { batch: TILES } );
   /// cmd( SetSpriteInstance { index: 42, transform: .., sprite: water, tint: WHITE } );
+  /// // RemoveInstance uses swap-remove: the last instance moves into slot 5.
+  /// // Update your entity→index map accordingly.
   /// cmd( RemoveInstance { index: 5 } );
   /// cmd( UnbindBatch );
   /// ```
@@ -329,11 +331,26 @@ mod private
     pub transform : Transform,
   }
 
-  /// Removes an instance at `index` from the bound batch.
+  /// Removes an instance at `index` from the bound batch using **swap-remove**.
+  ///
+  /// The last instance is moved into slot `index` to fill the gap.
+  /// If you maintain an external mapping of entity → instance index, you must
+  /// update it after removal: the entity that previously occupied the last slot
+  /// now lives at `index`.
+  ///
+  /// If `index` is already the last element no swap occurs — it is simply dropped.
+  ///
+  /// # Example
+  /// ```ignore
+  /// // Before: [A, B, C, D]  (len = 4)
+  /// cmd( RemoveInstance { index: 1 } ); // remove B
+  /// // After:  [A, D, C]     (len = 3) — D moved from index 3 to index 1
+  /// // → update your map: entity_D.index = 1
+  /// ```
   #[ derive( Debug, Clone, Copy ) ]
   pub struct RemoveInstance
   {
-    /// Instance index to remove.
+    /// Index of the instance to remove.
     pub index : u32,
   }
 

--- a/module/helper/tilemap_renderer/src/commands.rs
+++ b/module/helper/tilemap_renderer/src/commands.rs
@@ -305,6 +305,11 @@ mod private
   }
 
   /// Appends a new sprite instance to the bound batch.
+  ///
+  /// # Errors
+  ///
+  /// If the internal GPU buffer needs to grow and the allocation fails,
+  /// `submit` returns `RenderError::BackendError`.
   #[ derive( Debug, Clone, Copy ) ]
   pub struct AddSpriteInstance
   {
@@ -317,6 +322,11 @@ mod private
   }
 
   /// Appends a new mesh instance to the bound batch.
+  ///
+  /// # Errors
+  ///
+  /// If the internal GPU buffer needs to grow and the allocation fails,
+  /// `submit` returns `RenderError::BackendError`.
   #[ derive( Debug, Clone, Copy ) ]
   pub struct AddMeshInstance
   {
@@ -325,6 +335,13 @@ mod private
   }
 
   /// Updates a sprite instance at `index` within the bound batch.
+  ///
+  /// # Errors
+  ///
+  /// If `index >= batch.len()`, `submit` returns `RenderError::BackendError`.
+  /// Stale indices are easy to introduce after `RemoveInstance` (swap-remove
+  /// shifts the last element into the removed slot) — always update your
+  /// entity→index map after every removal.
   #[ derive( Debug, Clone, Copy ) ]
   pub struct SetSpriteInstance
   {
@@ -339,6 +356,11 @@ mod private
   }
 
   /// Updates a mesh instance at `index` within the bound batch.
+  ///
+  /// # Errors
+  ///
+  /// If `index >= batch.len()`, `submit` returns `RenderError::BackendError`.
+  /// See `SetSpriteInstance` for notes on stale indices after swap-remove.
   #[ derive( Debug, Clone, Copy ) ]
   pub struct SetMeshInstance
   {
@@ -356,6 +378,10 @@ mod private
   /// now lives at `index`.
   ///
   /// If `index` is already the last element no swap occurs — it is simply dropped.
+  ///
+  /// # Errors
+  ///
+  /// If `index >= batch.len()`, `submit` returns `RenderError::BackendError`.
   ///
   /// # Example
   /// ```ignore

--- a/module/helper/tilemap_renderer/src/lib.rs
+++ b/module/helper/tilemap_renderer/src/lib.rs
@@ -10,7 +10,6 @@
 #![ allow( clippy::too_many_arguments ) ]             // GPU draw / setup functions inherently take many parameters
 #![ allow( clippy::too_many_lines ) ]                 // Large match blocks in adapter implementations are expected
 #![ allow( clippy::std_instead_of_alloc ) ]           // wasm32+std: alloc crate is not separately linked; std::rc/std::collections are correct here
-#![ allow( clippy::match_same_arms ) ]                // Unimplemented placeholder arms (Path/Text/Group) are intentionally separate for readability
 
 //! Agnostic 2D rendering engine.
 //!

--- a/module/helper/tilemap_renderer/src/lib.rs
+++ b/module/helper/tilemap_renderer/src/lib.rs
@@ -1,7 +1,16 @@
-#![ allow( clippy::exhaustive_structs ) ] // POD command types are intentionally open; #[non_exhaustive] conflicts with Copy
-#![ allow( clippy::exhaustive_enums ) ]   // Small, stable enums meant to be matched exhaustively by adapter authors
-#![ allow( clippy::wildcard_imports ) ]   // mod_interface! generates glob re-exports; no per-item scope is available inside a proc-macro expansion
-#![ allow( clippy::min_ident_chars ) ]    // Short names like x, y, m are idiomatic in math/graphics contexts throughout this crate
+#![ allow( clippy::exhaustive_structs ) ]          // POD command types are intentionally open; #[non_exhaustive] conflicts with Copy
+#![ allow( clippy::exhaustive_enums ) ]            // Small, stable enums meant to be matched exhaustively by adapter authors
+#![ allow( clippy::wildcard_imports ) ]            // mod_interface! generates glob re-exports; no per-item scope is available inside a proc-macro expansion
+#![ allow( clippy::min_ident_chars ) ]             // Short names like x, y, m are idiomatic in math/graphics contexts throughout this crate
+#![ allow( clippy::missing_inline_in_public_items ) ] // Inline decisions belong to the optimizer for this crate size
+#![ allow( clippy::trivially_copy_pass_by_ref ) ]     // &u32 / &f32 params are idiomatic in GPU/math call sites throughout
+#![ allow( clippy::cast_possible_wrap ) ]             // GPU sizes / counts are bounded; u32→i32 wrapping is unreachable in practice
+#![ allow( clippy::cast_possible_truncation ) ]       // GPU values fit in their target types at all realistic sizes
+#![ allow( clippy::cast_precision_loss ) ]            // f32 precision loss is expected and acceptable in graphics code
+#![ allow( clippy::too_many_arguments ) ]             // GPU draw / setup functions inherently take many parameters
+#![ allow( clippy::too_many_lines ) ]                 // Large match blocks in adapter implementations are expected
+#![ allow( clippy::std_instead_of_alloc ) ]           // wasm32+std: alloc crate is not separately linked; std::rc/std::collections are correct here
+#![ allow( clippy::match_same_arms ) ]                // Unimplemented placeholder arms (Path/Text/Group) are intentionally separate for readability
 
 //! Agnostic 2D rendering engine.
 //!

--- a/module/helper/tilemap_renderer/src/lib.rs
+++ b/module/helper/tilemap_renderer/src/lib.rs
@@ -30,7 +30,7 @@
 //! use tilemap_renderer::{ commands::*, types::*, assets::*, backend::* };
 //! use tilemap_renderer::adapters::SvgBackend;
 //!
-//! // Note: SvgBackend, WebGlBackend, and TerminalBackend are stubs —
+//! // Note: SvgBackend and TerminalBackend are stubs —
 //! // implementations arrive in follow-up PRs.
 //! let config = RenderConfig { width : 800, height : 600, ..Default::default() };
 //! let mut svg = SvgBackend::new( config );

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -154,8 +154,14 @@ mod private
     /// Skew in radians. SVG: `skewX()` / `skewY()`. GPU: added to affine matrix.
     pub skew : [ f32; 2 ],
     /// Draw order. Higher values are drawn on top. Default 0.0.
-    /// SVG: backend sorts elements by depth before emitting.
-    /// GPU: depth buffer or painter's algorithm sort.
+    ///
+    /// qqq: depth sorting is not yet implemented in any backend. Currently
+    /// draw order is determined solely by command submission order: the
+    /// WebGL vertex shaders hardcode `gl_Position.z = 0.0` and never enable
+    /// `DEPTH_TEST`; the SVG backend emits elements in submission order
+    /// without sorting. Callers must pre-sort their commands if they need
+    /// ordering to match `depth`. Future work: honor this field via a depth
+    /// buffer (GPU) and a stable sort (SVG).
     pub depth : f32,
   }
 

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -170,19 +170,19 @@ mod private
     /// WebGL: honored via the depth buffer (`LEQUAL`, higher depth → on top).
     /// Valid range is `[-max_depth, max_depth]` (configured by
     /// `RenderConfig::max_depth`, default `1.0`); the shader divides by
-    /// `max_depth` and clamps the result to the clip-space `z` range, so
-    /// out-of-contract values saturate instead of being silently discarded.
-    /// Equal-depth draws fall back to submission order. **Only reliable for
-    /// fully opaque draws** — alpha-blended content whose farther pixels
-    /// arrive after nearer ones will z-fail instead of blending, so the
-    /// caller must submit translucent draws back-to-front (same convention
-    /// as a painter's algorithm renderer).
+    /// `max_depth` so the in-contract value maps into clip-space `[-1, 1]`.
+    /// Values outside this range produce clip-space `z` beyond `[-1, 1]` and
+    /// are clipped by the GPU — the draw disappears. Equal-depth draws fall
+    /// back to submission order. **Only reliable for fully opaque draws** —
+    /// alpha-blended content whose farther pixels arrive after nearer ones
+    /// will z-fail instead of blending, so the caller must submit translucent
+    /// draws back-to-front (same convention as a painter's algorithm renderer).
     ///
     /// In batch draws (`SpriteBatchParams` / `MeshBatchParams`) the GPU sees
     /// `parent_transform.depth + instance_transform.depth`, so the **sum**
-    /// must stay in `[-max_depth, max_depth]` for correct ordering. Saturated
-    /// instances collapse to the same clip `z` and fall back to submission
-    /// order among themselves.
+    /// — not each field individually — must stay in `[-max_depth, max_depth]`.
+    /// An out-of-range sum clips the instance the same way a single-draw
+    /// overflow does.
     ///
     /// qqq: SVG and terminal backends still emit in submission order and
     /// ignore this field. Callers targeting those backends must pre-sort.

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -155,13 +155,17 @@ mod private
     pub skew : [ f32; 2 ],
     /// Draw order. Higher values are drawn on top. Default 0.0.
     ///
-    /// qqq: depth sorting is not yet implemented in any backend. Currently
-    /// draw order is determined solely by command submission order: the
-    /// WebGL vertex shaders hardcode `gl_Position.z = 0.0` and never enable
-    /// `DEPTH_TEST`; the SVG backend emits elements in submission order
-    /// without sorting. Callers must pre-sort their commands if they need
-    /// ordering to match `depth`. Future work: honor this field via a depth
-    /// buffer (GPU) and a stable sort (SVG).
+    /// WebGL: honored via the depth buffer (`LEQUAL`, higher depth → on top).
+    /// Valid range is `[-1, 1]`; values outside get clipped. Equal-depth
+    /// draws fall back to submission order. **Only reliable for fully opaque
+    /// draws** — alpha-blended content whose farther pixels arrive after
+    /// nearer ones will z-fail instead of blending, so the caller must
+    /// submit translucent draws back-to-front (same convention as a
+    /// painter's algorithm renderer).
+    ///
+    /// qqq: SVG and terminal backends still emit in submission order and
+    /// ignore this field. Callers targeting those backends must pre-sort.
+    /// Future work: stable sort by `depth` in the SVG adapter.
     pub depth : f32,
   }
 

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -325,6 +325,7 @@ mod private
   /// - `filter = Linear`, `mipmap = Linear` → trilinear filtering (`LINEAR_MIPMAP_LINEAR`).
   /// - `filter = Linear`, `mipmap = Nearest` → bilinear within level, pick nearest level.
   /// - `filter = Nearest`, `mipmap = *` → nearest within level, chosen mip behavior.
+  ///
   /// `mag_filter` is always derived from [`SamplerFilter`] alone (magnification cannot use mips).
   #[ derive( Debug, Clone, Copy, Default ) ]
   pub enum MipmapMode

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -105,6 +105,17 @@ mod private
     /// Default background color (RGBA, 0.0–1.0).
     /// Used as the canvas background when no `Clear` command is issued.
     pub background : [ f32; 4 ],
+    /// Maximum magnitude of `Transform::depth` for GPU backends.
+    ///
+    /// Defines the usable per-field depth range as `[-max_depth, max_depth]`.
+    /// The shader divides the depth value by this before writing clip-space
+    /// `z`, so a larger value lets callers think in larger depth numbers
+    /// (e.g. `max_depth = 1000.0` allows `Transform::depth` in `[-1000, 1000]`)
+    /// at the cost of proportionally coarser depth buffer precision.
+    ///
+    /// Default `1.0` — backwards-compatible with the original `[-1, 1]` contract.
+    /// Ignored by SVG and terminal backends.
+    pub max_depth : f32,
   }
 
   impl Default for RenderConfig
@@ -118,6 +129,7 @@ mod private
         height : 600,
         antialias : Antialias::Default,
         background : [ 0.0, 0.0, 0.0, 1.0 ],
+        max_depth : 1.0,
       }
     }
   }
@@ -156,12 +168,21 @@ mod private
     /// Draw order. Higher values are drawn on top. Default 0.0.
     ///
     /// WebGL: honored via the depth buffer (`LEQUAL`, higher depth → on top).
-    /// Valid range is `[-1, 1]`; values outside get clipped. Equal-depth
-    /// draws fall back to submission order. **Only reliable for fully opaque
-    /// draws** — alpha-blended content whose farther pixels arrive after
-    /// nearer ones will z-fail instead of blending, so the caller must
-    /// submit translucent draws back-to-front (same convention as a
-    /// painter's algorithm renderer).
+    /// Valid range is `[-max_depth, max_depth]` (configured by
+    /// `RenderConfig::max_depth`, default `1.0`); the shader divides by
+    /// `max_depth` and clamps the result to the clip-space `z` range, so
+    /// out-of-contract values saturate instead of being silently discarded.
+    /// Equal-depth draws fall back to submission order. **Only reliable for
+    /// fully opaque draws** — alpha-blended content whose farther pixels
+    /// arrive after nearer ones will z-fail instead of blending, so the
+    /// caller must submit translucent draws back-to-front (same convention
+    /// as a painter's algorithm renderer).
+    ///
+    /// In batch draws (`SpriteBatchParams` / `MeshBatchParams`) the GPU sees
+    /// `parent_transform.depth + instance_transform.depth`, so the **sum**
+    /// must stay in `[-max_depth, max_depth]` for correct ordering. Saturated
+    /// instances collapse to the same clip `z` and fall back to submission
+    /// order among themselves.
     ///
     /// qqq: SVG and terminal backends still emit in submission order and
     /// ignore this field. Callers targeting those backends must pre-sort.

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -113,6 +113,10 @@ mod private
     /// (e.g. `max_depth = 1000.0` allows `Transform::depth` in `[-1000, 1000]`)
     /// at the cost of proportionally coarser depth buffer precision.
     ///
+    /// Must be `> 0.0`. Zero produces a shader divide-by-zero and nothing
+    /// renders; a negative value inverts the depth ordering. Neither case is
+    /// defended against at runtime.
+    ///
     /// Default `1.0` — backwards-compatible with the original `[-1, 1]` contract.
     /// Ignored by SVG and terminal backends.
     pub max_depth : f32,

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -354,7 +354,7 @@ mod private
     /// This equals pure `src * dst` only when `src_alpha = 1`; for semi-transparent
     /// sprites the multiply effect weakens with alpha, which is a known limitation.
     ///
-    /// **TODO (requires FBO):** Replace with the Photoshop-accurate formula
+    /// **qqq (requires FBO):** Replace with the Photoshop-accurate formula
     /// `dst * (src * src_alpha + (1 − src_alpha))`. This cannot be expressed as a
     /// single `blend_func` call with straight alpha — it needs a custom shader that
     /// reads the destination color from a bound FBO texture and computes the blend

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -315,7 +315,18 @@ mod private
     /// Source over (alpha blending).
     #[ default ]
     Normal,
-    /// SVG: `multiply`. GPU: src * dst.
+    /// SVG: `multiply`.
+    ///
+    /// **Current GPU approximation:** `blend_func(DST_COLOR, ONE_MINUS_SRC_ALPHA)`,
+    /// which computes `src_color * dst_color + dst_color * (1 − src_alpha)`.
+    /// This equals pure `src * dst` only when `src_alpha = 1`; for semi-transparent
+    /// sprites the multiply effect weakens with alpha, which is a known limitation.
+    ///
+    /// **TODO (requires FBO):** Replace with the Photoshop-accurate formula
+    /// `dst * (src * src_alpha + (1 − src_alpha))`. This cannot be expressed as a
+    /// single `blend_func` call with straight alpha — it needs a custom shader that
+    /// reads the destination color from a bound FBO texture and computes the blend
+    /// in the fragment shader, or a two-pass approach (blit dst to FBO, sample in shader).
     Multiply,
     /// SVG: `screen`. GPU: 1 - (1-src)*(1-dst).
     Screen,

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -319,7 +319,13 @@ mod private
     Multiply,
     /// SVG: `screen`. GPU: 1 - (1-src)*(1-dst).
     Screen,
-    /// SVG: `overlay`.
+    /// SVG: `overlay`. Photoshop-style: Multiply when dst < 0.5, Screen when dst > 0.5.
+    ///
+    /// **Not expressible as a single `blend_func` call.** Correct implementation requires
+    /// a custom shader or a separate FBO pass. Until that is implemented, adapters that
+    /// cannot support this mode must fall back to `Normal` and should document that
+    /// limitation; this variant exists so that callers can express intent without
+    /// requiring a capabilities check up-front.
     Overlay,
     /// Additive blending. GPU: src + dst.
     Add,

--- a/module/helper/tilemap_renderer/src/types.rs
+++ b/module/helper/tilemap_renderer/src/types.rs
@@ -295,7 +295,8 @@ mod private
 
   /// Texture sampling filter.
   /// SVG: `image-rendering` CSS property.
-  /// GPU: `mag_filter` / `min_filter` on the texture sampler.
+  /// GPU: `mag_filter` on the sampler, and the within-level component of `min_filter`
+  /// when combined with [`MipmapMode`].
   #[ derive( Debug, Clone, Copy, Default ) ]
   pub enum SamplerFilter
   {
@@ -303,6 +304,27 @@ mod private
     Nearest,
     /// Bilinear interpolation: smooth scaling.
     #[ default ]
+    Linear,
+  }
+
+  /// Mipmap generation and between-level interpolation.
+  ///
+  /// GPU-only hint: SVG and other non-GPU backends ignore this. On GPU backends,
+  /// `Nearest`/`Linear` cause mipmap chains to be generated at load time and
+  /// select the between-level component of `min_filter`:
+  /// - `filter = Linear`, `mipmap = Linear` → trilinear filtering (`LINEAR_MIPMAP_LINEAR`).
+  /// - `filter = Linear`, `mipmap = Nearest` → bilinear within level, pick nearest level.
+  /// - `filter = Nearest`, `mipmap = *` → nearest within level, chosen mip behavior.
+  /// `mag_filter` is always derived from [`SamplerFilter`] alone (magnification cannot use mips).
+  #[ derive( Debug, Clone, Copy, Default ) ]
+  pub enum MipmapMode
+  {
+    /// No mipmaps. `min_filter` uses `SamplerFilter` directly.
+    #[ default ]
+    Off,
+    /// Generate mipmaps; pick the nearest mip level without blending between levels.
+    Nearest,
+    /// Generate mipmaps; linearly blend between the two nearest mip levels.
     Linear,
   }
 
@@ -408,6 +430,7 @@ mod_interface::mod_interface!
   own use TextAnchor;
   own use Topology;
   own use SamplerFilter;
+  own use MipmapMode;
   own use BlendMode;
   own use FillRef;
   own use asset;

--- a/module/helper/tilemap_renderer/tests/assets_test.rs
+++ b/module/helper/tilemap_renderer/tests/assets_test.rs
@@ -32,8 +32,8 @@ fn assets_validate_no_duplicates()
   let assets = Assets
   {
     images : vec![
-      ImageAsset { id : ResourceId::new( 0 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear },
-      ImageAsset { id : ResourceId::new( 1 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear },
+      ImageAsset { id : ResourceId::new( 0 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear, mipmap : MipmapMode::Off },
+      ImageAsset { id : ResourceId::new( 1 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear, mipmap : MipmapMode::Off },
     ],
     ..empty_assets()
   };
@@ -48,8 +48,8 @@ fn assets_validate_duplicate_image_ids()
   let assets = Assets
   {
     images : vec![
-      ImageAsset { id : ResourceId::new( 5 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear },
-      ImageAsset { id : ResourceId::new( 5 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear },
+      ImageAsset { id : ResourceId::new( 5 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear, mipmap : MipmapMode::Off },
+      ImageAsset { id : ResourceId::new( 5 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear, mipmap : MipmapMode::Off },
     ],
     ..empty_assets()
   };
@@ -85,7 +85,7 @@ fn assets_validate_cross_type_ids_ok()
   let assets = Assets
   {
     images : vec![
-      ImageAsset { id : ResourceId::new( 0 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear },
+      ImageAsset { id : ResourceId::new( 0 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear, mipmap : MipmapMode::Off },
     ],
     geometries : vec![
       GeometryAsset { id : ResourceId::new( 0 ), positions : Source::Bytes( vec![] ), uvs : None, indices : None, data_type : DataType::U16 },
@@ -103,8 +103,8 @@ fn assets_validate_multiple_duplicate_types()
   let assets = Assets
   {
     images : vec![
-      ImageAsset { id : ResourceId::new( 0 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear },
-      ImageAsset { id : ResourceId::new( 0 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear },
+      ImageAsset { id : ResourceId::new( 0 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear, mipmap : MipmapMode::Off },
+      ImageAsset { id : ResourceId::new( 0 ), source : ImageSource::Encoded( vec![] ), filter : SamplerFilter::Linear, mipmap : MipmapMode::Off },
     ],
     sprites : vec![
       SpriteAsset { id : ResourceId::new( 1 ), sheet : ResourceId::new( 0 ), region : [ 0.0; 4 ] },

--- a/module/helper/tilemap_renderer/tests/backend_test.rs
+++ b/module/helper/tilemap_renderer/tests/backend_test.rs
@@ -1,3 +1,5 @@
+#![ allow( clippy::min_ident_chars ) ]
+#![ allow( clippy::struct_field_names ) ]   // ErrorBackend fields named *_error intentionally mirror the trait methods
 //! Backend trait contract tests.
 //!
 //! A minimal `TestBackend` implementation verifies that:

--- a/module/helper/tilemap_renderer/tests/backend_test.rs
+++ b/module/helper/tilemap_renderer/tests/backend_test.rs
@@ -401,4 +401,5 @@ fn backend_capabilities_default_all_false()
   assert!( !c.blend_modes );
   assert!( !c.text_on_path );
   assert_eq!( c.max_texture_size, 0 );
+  assert!( c.supported_blend_modes.is_empty() );
 }

--- a/module/helper/tilemap_renderer/tests/types_test.rs
+++ b/module/helper/tilemap_renderer/tests/types_test.rs
@@ -4,7 +4,7 @@
 //! Covers:
 //! - `Transform` identity state, translation matrix slots, scale diagonal, 90-degree rotation
 //! - `ResourceId` type-safe equality and debug formatting
-//! - `RenderConfig` default field values (width, height, antialias, background color, max_depth)
+//! - `RenderConfig` default field values (width, height, antialias, background color, `max_depth`)
 
 use tilemap_renderer::types::*;
 

--- a/module/helper/tilemap_renderer/tests/types_test.rs
+++ b/module/helper/tilemap_renderer/tests/types_test.rs
@@ -1,3 +1,4 @@
+#![ allow( clippy::min_ident_chars ) ]
 //! Types tests.
 //!
 //! Covers:

--- a/module/helper/tilemap_renderer/tests/types_test.rs
+++ b/module/helper/tilemap_renderer/tests/types_test.rs
@@ -4,7 +4,7 @@
 //! Covers:
 //! - `Transform` identity state, translation matrix slots, scale diagonal, 90-degree rotation
 //! - `ResourceId` type-safe equality and debug formatting
-//! - `RenderConfig` default field values (width, height, antialias, background color)
+//! - `RenderConfig` default field values (width, height, antialias, background color, max_depth)
 
 use tilemap_renderer::types::*;
 
@@ -129,4 +129,5 @@ fn render_config_default()
   assert!( config.background[ 1 ].abs() < 1e-6 );
   assert!( config.background[ 2 ].abs() < 1e-6 );
   assert!( ( config.background[ 3 ] - 1.0 ).abs() < 1e-6 );
+  assert!( ( config.max_depth - 1.0 ).abs() < 1e-6 );
 }


### PR DESCRIPTION
## Summary

Implements the `adapter-webgl` backend for `tilemap_renderer` on `wasm32-unknown-unknown` via the `minwebgl` crate. Replaces the previous 7-line stub with a full partial implementation covering the core tilemap use-case (thousands of instanced sprites/meshes).

## What is implemented

- **`ArrayBuffer<T>`** — GPU-side `Vec` with 2× grow via `copy_buffer_sub_data` (GPU-to-GPU, no CPU readback)
- **Compile-time layout assertions** — `SpriteInstanceData` (68 B) and `MeshInstanceData` (36 B) verified at compile time
- **Single draws** — `Clear`, `Mesh` (geometry + topology + optional texture), `Sprite` (tint + blend)
- **Instanced batch lifecycle** — `CreateSpriteBatch` / `CreateMeshBatch`, `Bind` / `Add` / `Set` / `Remove` / `Unbind`, `DrawBatch`, `DeleteBatch` for both sprite and mesh batches
- **Per-batch VAO** — set up at create/unbind time, bind-only at draw time
- **Asset loading** — images (Bitmap sync + Path async via `spawn_local`), sprites, geometries (sync + async)
- **Blend modes** — Normal, Add, Multiply, Screen, Overlay
- **Shaders** — `sprite.vert/frag`, `sprite_batch.vert/frag`, `mesh.vert/frag`, `mesh_batch.vert`

## What is intentionally not implemented (silent no-ops with TODO markers)

Path, Text, Group, Effect commands are matched and silently skipped in `submit()`. `ImageSource::Encoded` is skipped with a TODO. Gradients, patterns and clip masks are not loaded into GPU resources. These are deferred to follow-up PRs.

`capabilities()` honestly reports these as `false` — only `meshes`, `sprites`, `batches`, and `blend_modes` are `true`.

## Fixes included

**Sprite single-draw zero-size quad** — `sprite.vert` originally declared `a_position`/`a_uv` vertex attributes, but `SpriteRenderer::draw()` unbinds the VAO before calling `draw_arrays`. All 4 vertices read `(0, 0)`, collapsing the quad to a point. Fixed by replacing attribute inputs with `gl_VertexID`-based quad generation — the same pattern used in `sprite_batch.vert`.

**Async geometry + mesh batch race** — When a geometry asset uses `Source::Path`, an empty `GpuGeometry` (all buffers `None`) is registered immediately and a `spawn_local` future fetches the data. If `CreateMeshBatch` and `UnbindBatch` are called in the same synchronous wave (before the future runs), `setup_mesh_batch_vao` only configures instance attribs — geometry attribs are skipped because `position_buffer` is `None`. After the async fetch completes, the spawn_local closure now iterates over all batches referencing this geometry and calls `setup_mesh_batch_vao` again with the populated geometry. Drawing before the geometry loads draws nothing (`vertex_count = 0`), which is correct.

**`RemoveInstance` swap-remove semantics documented** — `RemoveInstance` uses swap-remove (O(1)): the last instance moves into the removed slot. Callers that maintain an entity→index mapping must update it after removal. This is now documented on the struct with an example.

## Deliberate decisions

**`target_arch = "wasm32"` guard removed from `adapters/mod.rs`** — The previous guard caused `rust-analyzer` to exclude `webgl.rs` from analysis even with `allTargets: true`, making the file invisible to IDE tooling. The feature is documented as wasm32-only in `Cargo.toml`. In practice no one enables `adapter-webgl` on a native target; removing the cfg guard is a net improvement to developer experience with no real-world downside.

**`capabilities()` returns `false` for unimplemented features** — Previous stub returned `true` for `paths`, `text`, `gradients`, `patterns`, `clip_masks`, `effects`. These are all silent no-ops; advertising them as supported would mislead user code that queries capabilities before submitting commands.