### PR TITLE
APPROVED : Add Pointer Type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ version = "0.1.0"
 path = "module/helper/animation"
 
 [workspace.dependencies.browser_input]
-version = "0.3.0"
+version = "0.4.0"
 path = "module/helper/browser_input"
 
 [workspace.dependencies.tiles_tools]

--- a/module/helper/browser_input/Cargo.toml
+++ b/module/helper/browser_input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "browser_input"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Kostiantyn Mysnyk <wandalen@obox.systems>"]

--- a/module/helper/browser_input/changelog.md
+++ b/module/helper/browser_input/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- `PointerType` enum representing the physical device kind behind a pointer event (`Mouse`, `Touch`, `Pen`, `Unknown`); marked `#[non_exhaustive]` to guard against future DOM spec extensions
+- `Input::last_pointer_type()` — returns the `PointerType` of the most recently observed pointer event; `Unknown` until the first pointer event fires or when the browser reports an unrecognised `pointerType` string
+- `PointerType::from_dom_str(s: &str)` — public constructor converting a DOM `PointerEvent.pointerType` string to `PointerType`; consistent with `MouseButton::from_button` / `KeyboardKey::from_code`
+
 ## [0.3.0] - 2026-02-20
 
 ### Breaking Changes

--- a/module/helper/browser_input/readme.md
+++ b/module/helper/browser_input/readme.md
@@ -8,6 +8,7 @@ Captures DOM events into a per-frame event queue and maintains a persistent inpu
 
 - **Unified pointer model** — mouse, touch, and stylus handled identically via `pointermove` / `pointerdown` / `pointerup` / `pointercancel`
 - **Multi-touch tracking** — `active_pointers()` returns all current contacts as `(pointer_id, position)` pairs; use this for pinch-to-zoom or two-finger pan
+- **Device type detection** — `last_pointer_type()` returns the `PointerType` (`Mouse` / `Touch` / `Pen` / `Unknown`) of the most recent pointer event
 - **Keyboard events** — full key press/release with modifier detection
 - **Scroll wheel** — raw `delta_x / delta_y / delta_z` from the browser
 - **Mobile-ready** — sets `touch-action: none` on the target element and calls `setPointerCapture` on every `pointerdown` so drag events keep firing even when a finger moves outside the element
@@ -113,6 +114,7 @@ input.is_button_down( MouseButton::Main )        // -> bool  (tracks last press/
 input.pointer_position()                         // -> I32x2   (last moved pointer; non-deterministic with multiple touches)
 input.active_pointers()                          // -> &[(i32, I32x2)]
 input.scroll()                                   // -> &F64x3  (accumulated wheel delta since last clear_events)
+input.last_pointer_type()                        // -> PointerType  (Mouse/Touch/Pen/Unknown; Unknown until first event)
 ```
 
 ### Mouse buttons

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -454,6 +454,11 @@ impl Input
   /// Returns [`PointerType::Unknown`] until the first pointer event arrives.
   /// Useful for branching UI on hybrid devices — e.g. hiding a cursor-follow
   /// preview when no finger is on the screen but keeping it for mouse hover.
+  ///
+  /// # Test coverage
+  /// The string-to-variant mapping is covered by `PointerType::from_dom_str` unit tests.
+  /// End-to-end wiring through DOM callbacks requires a `wasm-bindgen-test` environment
+  /// and is not covered on the native target.
   pub fn last_pointer_type( &self ) -> PointerType
   {
     self.last_pointer_type.get()

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -452,8 +452,13 @@ impl Input
   /// Returns the [`PointerType`] of the most recently observed pointer event.
   ///
   /// Returns [`PointerType::Unknown`] until the first pointer event arrives.
-  /// Useful for branching UI on hybrid devices — e.g. hiding a cursor-follow
-  /// preview when no finger is on the screen but keeping it for mouse hover.
+  /// Useful for adapting UI to the active input modality on hybrid devices —
+  /// e.g. switching cursor-follow behaviour once the user switches from mouse
+  /// to touch.
+  ///
+  /// Note: this value does not reset when pointers are released; after a finger
+  /// lifts, it persists as `Touch` until the next pointer event. To check
+  /// whether any pointer is currently active, use [`Input::active_pointers`].
   ///
   /// # Test coverage
   /// The string-to-variant mapping is covered by `PointerType::from_dom_str` unit tests.

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -86,7 +86,7 @@ impl PointerType
 {
   /// Convert from the DOM `PointerEvent.pointerType` string.
   #[ inline ]
-  fn from_dom_str( s : &str ) -> Self
+  pub fn from_dom_str( s : &str ) -> Self
   {
     match s
     {

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -12,7 +12,7 @@ use web_sys::
   PointerEvent,
   WheelEvent,
 };
-use std::{ cell::{ Ref, RefCell }, rc::Rc, fmt };
+use std::{ cell::{ Cell, Ref, RefCell }, rc::Rc, fmt };
 use strum::EnumCount as _;
 use crate::keyboard::KeyboardKey;
 use crate::mouse::MouseButton;
@@ -59,6 +59,42 @@ pub enum Action
   Press,
   /// Indicates that a button or key has been released.
   Release,
+}
+
+/// The kind of physical input device that produced a pointer event.
+///
+/// Mirrors the `pointerType` field of the DOM `PointerEvent` interface. Useful
+/// for branching UI behaviour on devices where touch and mouse coexist — e.g.
+/// hiding a cursor-follow preview when no finger is on the screen.
+#[ derive( Debug, Clone, Copy, PartialEq, Eq, Default ) ]
+pub enum PointerType
+{
+  /// A mouse, trackpad, or other indirect pointing device.
+  Mouse,
+  /// A finger on a touchscreen.
+  Touch,
+  /// A stylus or active pen.
+  Pen,
+  /// No pointer events have been seen yet, or the device reported an
+  /// unrecognised `pointerType`.
+  #[ default ]
+  Unknown,
+}
+
+impl PointerType
+{
+  /// Convert from the DOM `PointerEvent.pointerType` string.
+  #[ inline ]
+  fn from_dom_str( s : &str ) -> Self
+  {
+    match s
+    {
+      "mouse" => Self::Mouse,
+      "touch" => Self::Touch,
+      "pen"   => Self::Pen,
+      _       => Self::Unknown,
+    }
+  }
 }
 
 /// Enumerates the different types of input events that can be captured.
@@ -167,6 +203,10 @@ pub struct Input
   pointer_event_target : Option< EventTarget >,
   /// The current state of inputs (e.g., which keys are down).
   state : State,
+  /// Type of the most recently observed pointer event. Shared with the pointer
+  /// callbacks via [`Rc<Cell>`] so they can write it without going through the
+  /// event queue — keeps the enum `EventType` API stable.
+  last_pointer_type : Rc< Cell< PointerType > >,
 }
 
 impl Input
@@ -193,6 +233,7 @@ impl Input
     F : Fn( &PointerEvent ) -> I32x2 + 'static
   {
     let event_queue = Rc::new( RefCell::new( Vec::< Event >::new() ) );
+    let last_pointer_type = Rc::new( Cell::new( PointerType::default() ) );
 
     // Wrap in Rc<dyn Fn> so both the button and move closures can share the same extractor.
     let get_coords : Rc< dyn Fn( &PointerEvent ) -> I32x2 > = Rc::new( get_coords );
@@ -201,12 +242,14 @@ impl Input
     {
       let event_queue = event_queue.clone();
       let get_coords = get_coords.clone();
+      let last_pointer_type = last_pointer_type.clone();
       move | event : PointerEvent |
       {
         let pointer_id = event.pointer_id();
         let pos = ( *get_coords )( &event );
         let button = MouseButton::from_button( event.button() );
         let action = if event.type_() == "pointerdown" { Action::Press } else { Action::Release };
+        last_pointer_type.set( PointerType::from_dom_str( &event.pointer_type() ) );
 
         // On press, capture the pointer so drag events keep arriving even when the
         // finger or cursor moves outside the target element's bounding box.
@@ -232,11 +275,13 @@ impl Input
     let pointercancel_callback =
     {
       let event_queue = event_queue.clone();
+      let last_pointer_type = last_pointer_type.clone();
       move | event : PointerEvent |
       {
         // The Pointer Events spec does not guarantee valid coordinates or button data
         // for pointercancel; only the pointer_id is reliable.
         let pointer_id = event.pointer_id();
+        last_pointer_type.set( PointerType::from_dom_str( &event.pointer_type() ) );
         let event_type = EventType::PointerCancel( pointer_id );
         let alt = event.alt_key();
         let ctrl = event.ctrl_key();
@@ -248,10 +293,12 @@ impl Input
     let pointermove_callback =
     {
       let event_queue = event_queue.clone();
+      let last_pointer_type = last_pointer_type.clone();
       move | event : PointerEvent |
       {
         let pointer_id = event.pointer_id();
         let position = ( *get_coords )( &event );
+        last_pointer_type.set( PointerType::from_dom_str( &event.pointer_type() ) );
         let event_type = EventType::PointerMove( pointer_id, position );
         let alt = event.alt_key();
         let ctrl = event.ctrl_key();
@@ -307,6 +354,7 @@ impl Input
       wheel_closure,
       pointer_event_target,
       state : State::new(),
+      last_pointer_type,
     };
 
     let window = web_sys::window().ok_or( BrowserInputError::WindowNotAvailable )?;
@@ -398,6 +446,16 @@ impl Input
   pub fn scroll( &self ) -> &F64x3
   {
     &self.state.scroll
+  }
+
+  /// Returns the [`PointerType`] of the most recently observed pointer event.
+  ///
+  /// Returns [`PointerType::Unknown`] until the first pointer event arrives.
+  /// Useful for branching UI on hybrid devices — e.g. hiding a cursor-follow
+  /// preview when no finger is on the screen but keeping it for mouse hover.
+  pub fn last_pointer_type( &self ) -> PointerType
+  {
+    self.last_pointer_type.get()
   }
 
   /// Returns all currently active pointer contacts as a slice of `(pointer_id, position)` pairs.

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -280,7 +280,7 @@ impl Input
       move | event : PointerEvent |
       {
         // The Pointer Events spec does not guarantee valid coordinates or button data
-        // for pointercancel; only the pointer_id is reliable.
+        // for pointercancel.
         let pointer_id = event.pointer_id();
         last_pointer_type.set( PointerType::from_dom_str( &event.pointer_type() ) );
         let event_type = EventType::PointerCancel( pointer_id );

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -66,6 +66,7 @@ pub enum Action
 /// Mirrors the `pointerType` field of the DOM `PointerEvent` interface. Useful
 /// for branching UI behaviour on devices where touch and mouse coexist — e.g.
 /// hiding a cursor-follow preview when no finger is on the screen.
+#[ non_exhaustive ]
 #[ derive( Debug, Clone, Copy, PartialEq, Eq, Default ) ]
 pub enum PointerType
 {

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -77,7 +77,8 @@ pub enum PointerType
   /// A stylus or active pen.
   Pen,
   /// No pointer events have been seen yet, or the device reported an
-  /// unrecognised `pointerType`.
+  /// unrecognised `pointerType`. These two cases are intentionally
+  /// indistinguishable from the caller's perspective.
   #[ default ]
   Unknown,
 }
@@ -451,7 +452,8 @@ impl Input
 
   /// Returns the [`PointerType`] of the most recently observed pointer event.
   ///
-  /// Returns [`PointerType::Unknown`] until the first pointer event arrives.
+  /// Returns [`PointerType::Unknown`] before the first pointer event fires, or
+  /// when the browser reports an unrecognised `pointerType` string.
   /// Useful for adapting UI to the active input modality on hybrid devices —
   /// e.g. switching cursor-follow behaviour once the user switches from mouse
   /// to touch.

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -93,7 +93,7 @@ impl PointerType
       "mouse" => Self::Mouse,
       "touch" => Self::Touch,
       "pen"   => Self::Pen,
-      _       => Self::Unknown,
+      _       => Self::Unknown, // includes "" — spec-defined for when device type cannot be determined
     }
   }
 }

--- a/module/helper/browser_input/src/input.rs
+++ b/module/helper/browser_input/src/input.rs
@@ -583,3 +583,45 @@ impl Drop for Input
     );
   }
 }
+
+#[ cfg( test ) ]
+mod tests
+{
+  use super::PointerType;
+
+  #[ test ]
+  fn from_dom_str_mouse()
+  {
+    assert_eq!( PointerType::from_dom_str( "mouse" ), PointerType::Mouse );
+  }
+
+  #[ test ]
+  fn from_dom_str_touch()
+  {
+    assert_eq!( PointerType::from_dom_str( "touch" ), PointerType::Touch );
+  }
+
+  #[ test ]
+  fn from_dom_str_pen()
+  {
+    assert_eq!( PointerType::from_dom_str( "pen" ), PointerType::Pen );
+  }
+
+  #[ test ]
+  fn from_dom_str_empty_string_is_unknown()
+  {
+    assert_eq!( PointerType::from_dom_str( "" ), PointerType::Unknown );
+  }
+
+  #[ test ]
+  fn from_dom_str_unrecognised_is_unknown()
+  {
+    assert_eq!( PointerType::from_dom_str( "stylus" ), PointerType::Unknown );
+  }
+
+  #[ test ]
+  fn default_is_unknown()
+  {
+    assert_eq!( PointerType::default(), PointerType::Unknown );
+  }
+}


### PR DESCRIPTION
# Add PointerType to browser_input

Exposes which physical device — mouse, touch, or pen — produced the most recent pointer event, so UI can branch on input modality on hybrid devices.

## Motivation

On devices where touch and mouse coexist, some UI affordances only make sense for one modality. For example, a cursor-follow preview should track the mouse on hover but be hidden when the last interaction was a finger tap. Until now browser_input discarded the DOM PointerEvent.pointerType field, leaving consumers no way to tell these apart.

## Changes

- New PointerType enum (Mouse, Touch, Pen, Unknown) mirroring the DOM pointerType string, with a from_dom_str parser. Unknown is the Default and covers both "no event seen yet" and unrecognised values.
- Tracking — every pointerdown/pointerup, pointermove, and pointercancel callback now records the event's pointer type into an Rc<Cell<PointerType>> shared with Input.
- New accessor — Input::last_pointer_type() returns the type of the most recently observed pointer event (Unknown until the first one arrives).

## Design notes

The state is shared via Rc<Cell<…>> rather than threaded through the EventType enum or the event queue. This keeps the existing EventType API stable and lets the callbacks write the value without enqueuing anything — last_pointer_type() is a plain getter, decoupled from event consumption.

## Scope

Single file touched: module/helper/browser_input/src/input.rs (+59/−1). Purely additive — no existing behaviour or signatures change.
