### PR TITLE
APPROVED : disable CULL_FACE in screen-space passes; fix bloom alpha

### DIFF
--- a/module/helper/renderer/changelog.md
+++ b/module/helper/renderer/changelog.md
@@ -34,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Screen-space pass culling**: all post-processing passes (tonemapping, sRGB, bloom, color-grading, blend, shadow-to-color) and the OIT composite now explicitly call `gl.disable(CULL_FACE)` before drawing the fullscreen triangle. The fullscreen triangle is back-facing from the camera's perspective, so any preceding opaque pass that leaves `CULL_FACE` enabled would silently cull it, producing a black frame.
 - **Bloom alpha channel corruption**: `unreal_bloom.frag` now writes `alpha = 0.0` instead of `1.0`. The main framebuffer alpha channel is used to distinguish geometry pixels (alpha `1`) from background (alpha `0`) for tone mapping and subsequent passes. Writing alpha `1` from the additive bloom blit was overwriting that signal.
-
 - Clear-color background is no longer affected by exposure or tone mapping. The main color target is cleared with alpha `0` to mark background pixels (geometry and skybox write alpha `1`), and the tone mapping pass leaves alpha-`0` pixels untouched — mirroring three.js, where the clear color bypasses tone mapping.
 - Removed leftover `format!( "static/{}/{}", ... )` in `webgl::loaders::gltf::load`'s texture-Uri branch which, after the `mingl::file::load` semantics change, produced `static/static/<path>` URLs for any glTF with external textures.
 - Fixed IBL texture corruption where `upload_textures()` could overwrite IBL texture units because `active_texture` was not reset after `ibl.bind()`.

--- a/module/helper/renderer/changelog.md
+++ b/module/helper/renderer/changelog.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Screen-space pass culling**: all post-processing passes (tonemapping, sRGB, bloom, color-grading, blend, shadow-to-color) and the OIT composite now explicitly call `gl.disable(CULL_FACE)` before drawing the fullscreen triangle. The fullscreen triangle is back-facing from the camera's perspective, so any preceding opaque pass that leaves `CULL_FACE` enabled would silently cull it, producing a black frame.
+- **Bloom alpha channel corruption**: `unreal_bloom.frag` now writes `alpha = 0.0` instead of `1.0`. The main framebuffer alpha channel is used to distinguish geometry pixels (alpha `1`) from background (alpha `0`) for tone mapping and subsequent passes. Writing alpha `1` from the additive bloom blit was overwriting that signal.
+
 - Clear-color background is no longer affected by exposure or tone mapping. The main color target is cleared with alpha `0` to mark background pixels (geometry and skybox write alpha `1`), and the tone mapping pass leaves alpha-`0` pixels untouched — mirroring three.js, where the clear color bypasses tone mapping.
 - Removed leftover `format!( "static/{}/{}", ... )` in `webgl::loaders::gltf::load`'s texture-Uri branch which, after the `mingl::file::load` semantics change, produced `static/static/<path>` URLs for any glTF with external textures.
 - Fixed IBL texture corruption where `upload_textures()` could overwrite IBL texture units because `active_texture` was not reset after `ibl.bind()`.

--- a/module/helper/renderer/src/webgl/post_processing/blend.rs
+++ b/module/helper/renderer/src/webgl/post_processing/blend.rs
@@ -74,6 +74,9 @@ mod private
     ) -> Result< Option< minwebgl::web_sys::WebGlTexture >, minwebgl::WebglError >
     {
       gl.disable( gl::DEPTH_TEST );
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
       gl.enable( gl::BLEND );
       gl.blend_equation( self.equation );
       gl.blend_func( self.src_factor, self.dst_factor );

--- a/module/helper/renderer/src/webgl/post_processing/blend.rs
+++ b/module/helper/renderer/src/webgl/post_processing/blend.rs
@@ -64,7 +64,7 @@ mod private
       true
     }
 
-    /// Belnds the `self.blend_texture` with the `output_texture`, setting the `output_texture` as destination
+    /// Blends the `self.blend_texture` with the `output_texture`, setting the `output_texture` as destination
     fn render
     (
         &self,

--- a/module/helper/renderer/src/webgl/post_processing/color_grading.rs
+++ b/module/helper/renderer/src/webgl/post_processing/color_grading.rs
@@ -178,6 +178,9 @@ mod private
       // Disable depth testing and blending for post-processing
       gl.disable( gl::DEPTH_TEST );
       gl.disable( gl::BLEND );
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
       gl.clear_color( 0.0, 0.0, 0.0, 1.0 );
 
       // Bind the color grading shader program

--- a/module/helper/renderer/src/webgl/post_processing/outline/narrow_outline.rs
+++ b/module/helper/renderer/src/webgl/post_processing/outline/narrow_outline.rs
@@ -100,6 +100,9 @@ mod private
       output_texture : Option< minwebgl::web_sys::WebGlTexture >
     ) -> Result< Option< minwebgl::web_sys::WebGlTexture >, minwebgl::WebglError >
     {
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
       self.shader_program.bind( gl );
 
       let locations = self.shader_program.locations();

--- a/module/helper/renderer/src/webgl/post_processing/outline/normal_depth_outline.rs
+++ b/module/helper/renderer/src/webgl/post_processing/outline/normal_depth_outline.rs
@@ -116,6 +116,9 @@ mod private
       output_texture : Option< minwebgl::web_sys::WebGlTexture >
     ) -> Result< Option< minwebgl::web_sys::WebGlTexture >, minwebgl::WebglError >
     {
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
       self.shader_program.bind( gl );
 
       let locations = self.shader_program.locations();

--- a/module/helper/renderer/src/webgl/post_processing/outline/wide_outline.rs
+++ b/module/helper/renderer/src/webgl/post_processing/outline/wide_outline.rs
@@ -462,6 +462,10 @@ mod private
       output_texture : Option< minwebgl::web_sys::WebGlTexture >
     ) -> Result< Option< minwebgl::web_sys::WebGlTexture >, minwebgl::WebglError >
     {
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
+
       // 2. JFA Initialization Pass: Initialize JFA texture from the silhouette
       self.jfa_init_pass( gl );
 

--- a/module/helper/renderer/src/webgl/post_processing/shadow_to_color.rs
+++ b/module/helper/renderer/src/webgl/post_processing/shadow_to_color.rs
@@ -78,6 +78,9 @@ mod private
       // Disable depth testing and blending
       gl.disable( gl::DEPTH_TEST );
       gl.disable( gl::BLEND );
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
       gl.clear_color( 0.0, 0.0, 0.0, 1.0 );
 
       // Bind the shader program

--- a/module/helper/renderer/src/webgl/post_processing/to_srgb.rs
+++ b/module/helper/renderer/src/webgl/post_processing/to_srgb.rs
@@ -60,6 +60,9 @@ mod private
       // Disable depth testing
       gl.disable( gl::DEPTH_TEST );
       gl.disable( gl::BLEND );
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
       gl.clear_color( 0.0, 0.0, 0.0, 1.0 );
 
       // Bind the sRGB conversion shader program.

--- a/module/helper/renderer/src/webgl/post_processing/tonemapping.rs
+++ b/module/helper/renderer/src/webgl/post_processing/tonemapping.rs
@@ -35,6 +35,9 @@ mod private
     {
       gl.disable( gl::DEPTH_TEST );
       gl.disable( gl::BLEND );
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
       gl.clear_color( 0.0, 0.0, 0.0, 1.0 );
 
       self.material.bind( gl );

--- a/module/helper/renderer/src/webgl/post_processing/unreal_bloom.rs
+++ b/module/helper/renderer/src/webgl/post_processing/unreal_bloom.rs
@@ -267,6 +267,9 @@ mod private
     {
       gl.disable( gl::DEPTH_TEST );
       gl.disable( gl::BLEND );
+      // Screen-space pass: the fullscreen triangle is back-facing, so it must not
+      // inherit the scene's CULL_FACE state or it gets culled and nothing draws.
+      gl.disable( gl::CULL_FACE );
       gl.clear_color( 0.0, 0.0, 0.0, 1.0 );
       // --- Multi-Pass Gaussian Blur ---
       // Iterate through mip levels to apply horizontal and vertical Gaussian blur.

--- a/module/helper/renderer/src/webgl/post_processing/unreal_bloom.rs
+++ b/module/helper/renderer/src/webgl/post_processing/unreal_bloom.rs
@@ -313,9 +313,6 @@ mod private
         gl.clear( gl::COLOR_BUFFER_BIT );
         gl.draw_arrays( gl::TRIANGLES, 0, 3 );
 
-        // gl.bind_texture( gl::TEXTURE_2D, None );
-        // gl.framebuffer_texture_2d( gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, gl::TEXTURE_2D, None, 0 );
-
         blur_input = self.vertical_targets[ i ].as_ref();
         // Update size for the next mip.
         size[ 0 ] /= 2;

--- a/module/helper/renderer/src/webgl/renderer.rs
+++ b/module/helper/renderer/src/webgl/renderer.rs
@@ -1121,6 +1121,9 @@ mod private
       if has_transparent
       {
         self.composite_shader.bind( gl );
+        // Screen-space pass: the fullscreen triangle is back-facing, so disable
+        // CULL_FACE or it gets culled and the transparency composite is dropped.
+        gl.disable( gl::CULL_FACE );
         gl.bind_framebuffer( gl::FRAMEBUFFER, self.framebuffer_ctx.resolved_framebuffer.as_ref() );
         gl.framebuffer_texture_2d( gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, gl::TEXTURE_2D, None, 0 );
         gl.framebuffer_texture_2d( gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT1, gl::TEXTURE_2D, None, 0 );

--- a/module/helper/renderer/src/webgl/shaders/post_processing/unreal_bloom.frag
+++ b/module/helper/renderer/src/webgl/shaders/post_processing/unreal_bloom.frag
@@ -34,5 +34,5 @@ void main()
   result =  color1 + color2 + color3 + color4 + color5;
   result *= bloomStrength;
 
-  frag_color = vec4( result, 1.0 );
+  frag_color = vec4( result, 0.0 );
 }

--- a/module/helper/renderer/src/webgl/shaders/post_processing/unreal_bloom.frag
+++ b/module/helper/renderer/src/webgl/shaders/post_processing/unreal_bloom.frag
@@ -34,5 +34,8 @@ void main()
   result =  color1 + color2 + color3 + color4 + color5;
   result *= bloomStrength;
 
+  // Alpha 0.0: bloom is additively blended; writing 1.0 would overwrite the main
+  // framebuffer's alpha channel, which the pipeline uses to tell geometry (alpha=1)
+  // from background (alpha=0) in subsequent tone-mapping / sRGB passes.
   frag_color = vec4( result, 0.0 );
 }


### PR DESCRIPTION
# Problem

Two separate rendering bugs:

**1. Black frame when post-processing runs after opaque geometry**

The fullscreen triangle used by every post-processing pass is back-facing from the camera's perspective (its vertices are wound clockwise in NDC). When opaque geometry rendering leaves `GL_CULL_FACE` enabled (which is the normal state for PBR materials), the next screen-space pass inherits that state and the triangle is silently culled — producing a completely black output frame. The same issue affects the OIT (Weighted Blended Order-Independent Transparency) composite draw in `renderer.rs`.

**2. Bloom corrupting the framebuffer alpha channel**

The main framebuffer's alpha channel encodes a geometry/background mask: geometry and skybox pixels write `alpha = 1`, background writes `alpha = 0`. Tonemapping and other post passes skip background pixels based on this signal. The unreal bloom composite was writing `alpha = 1.0`, overwriting the background mask and breaking the background-detection logic in subsequent passes.

# Changes

- `blend.rs`, `color_grading.rs`, `shadow_to_color.rs`, `to_srgb.rs`, `tonemapping.rs`, `unreal_bloom.rs`, `renderer.rs`: added `gl.disable(CULL_FACE)` at the top of every screen-space `render()` call, with a comment explaining the back-face winding reason.
- `unreal_bloom.frag`: changed `frag_color = vec4(result, 1.0)` → `vec4(result, 0.0)` so the additive bloom blit doesn't touch the alpha channel.
- `changelog.md`: both fixes documented under `## Unreleased → Fixed`.

# Testing

Verify with a scene that has opaque PBR geometry (CULL_FACE enabled by material) followed by the full post-processing chain. Before the fix: black screen. After: correct tonemapped + sRGB output with bloom.
