### PR TITLE
APPROVED : Removed stray println, update docs, add few tests

### DIFF
--- a/module/math/mdmath_core/src/vector/arithmetics.rs
+++ b/module/math/mdmath_core/src/vector/arithmetics.rs
@@ -184,6 +184,11 @@ mod private
 
   /// Computes the cross product of two 3D vectors.
   /// This function modifies the first vector in place.
+  ///
+  /// # Overflow
+  /// For integer scalars the per-component multiplications and subtractions are
+  /// not overflow-checked: they panic in debug / wrap in release once any
+  /// intermediate value leaves `E`'s range.
   #[ inline ]
   pub fn cross_mut< E, R, B >( r : &mut R, b : &B )
   where
@@ -220,6 +225,11 @@ mod private
   }
 
   /// Computes the cross product of two 3D vectors.
+  ///
+  /// # Overflow
+  /// For integer scalars the per-component multiplications and subtractions are
+  /// not overflow-checked: they panic in debug / wrap in release once any
+  /// intermediate value leaves `E`'s range.
   #[ inline ]
   pub fn cross< E, A, B >( a : &A, b : &B ) -> A
   where

--- a/module/math/ndarray_cg/src/d2/arithmetics/add.rs
+++ b/module/math/ndarray_cg/src/d2/arithmetics/add.rs
@@ -30,7 +30,6 @@ where
     }
   }
 
-  // println!( "a: {:?}, b: {:?}, r: {:?}", adim, bdim, rdim );
   for ( ( r_val, a_val ), b_val ) in r.iter_lsfirst_mut().zip( a.iter_lsfirst() ).zip( b.iter_lsfirst() )
   {
     *r_val = *a_val + *b_val;

--- a/module/math/ndarray_cg/src/d2/arithmetics/add.rs
+++ b/module/math/ndarray_cg/src/d2/arithmetics/add.rs
@@ -1,6 +1,10 @@
 use crate::*;
 
 /// Adds two matrices.
+///
+/// # Overflow
+/// For integer `E` the element-wise addition is not overflow-checked: it
+/// panics in debug / wraps in release once a sum leaves `E`'s range.
 #[ inline ]
 pub fn add< E, A, B, R >( r : &mut R, a : &A, b : &B )
 where
@@ -51,6 +55,9 @@ where
 {
   type Output = Self;
 
+  /// # Overflow
+  /// For integer `E` the element-wise addition is not overflow-checked: it
+  /// panics in debug / wraps in release once a sum leaves `E`'s range.
   #[ inline ]
   fn add( self, rhs : Self ) -> Self::Output
   {
@@ -71,6 +78,9 @@ where
 {
   type Output = Mat< ROWS, COLS, E, Descriptor >;
 
+  /// # Overflow
+  /// For integer `E` the element-wise addition is not overflow-checked: it
+  /// panics in debug / wraps in release once a sum leaves `E`'s range.
   fn add( self, rhs : &Mat< ROWS, COLS, E, Descriptor > ) -> Self::Output
   {
     let mut result = Self::Output::default();

--- a/module/math/ndarray_cg/src/d2/arithmetics/mul.rs
+++ b/module/math/ndarray_cg/src/d2/arithmetics/mul.rs
@@ -31,9 +31,6 @@ where
     }
   }
 
-  // println!( "a : {:?}, b : {:?}, r : {:?}", adim, bdim, rdim );
-  // println!( "a.lane( 0, 0 ) : {:?}", a.lane_iter( 0, 0 ).collect::< Vec< _ > >() );
-  // println!( "b.lane( 1, 0 ) : {:?}", a.lane_iter( 1, 0 ).collect::< Vec< _ > >() );
   for row in 0..adim[ 0 ]
   {
     for col in 0..bdim[ 1 ]

--- a/module/math/ndarray_cg/src/d2/arithmetics/mul.rs
+++ b/module/math/ndarray_cg/src/d2/arithmetics/mul.rs
@@ -1,6 +1,11 @@
 use crate::*;
 
 /// Multiplies two matrices.
+///
+/// # Overflow
+/// For integer `E` the inner-product accumulation is not overflow-checked: it
+/// panics in debug / wraps in release once a product or partial sum leaves
+/// `E`'s range.
 pub fn mul< E, A, B, R >( r : &mut R, a : &A, b : &B )
 where
   E : MatNum,
@@ -33,7 +38,6 @@ where
   {
     for col in 0..bdim[ 1 ]
     {
-      println!( "{:?}", ( row, col ) );
       *r.scalar_mut( nd::Ix2( row, col ) ) = a.lane_iter( 0, row )
       .zip( b.lane_iter( 1, col ) )
       .map( | ( a_val, b_val ) | *a_val * *b_val )
@@ -43,6 +47,11 @@ where
 }
 
 /// Multiplies vector by a matrix.
+///
+/// # Overflow
+/// For integer `E` the inner-product accumulation is not overflow-checked: it
+/// panics in debug / wraps in release once a product or partial sum leaves
+/// `E`'s range.
 pub fn mul_mat_vec< E, A, B, R, const ROWS : usize >( r : &mut R, a : &A, b : &B )
 where
   E : MatNum,
@@ -85,6 +94,10 @@ where
 {
   type Output = Mat< ROWS, COLS2, E, Descriptor >;
 
+  /// # Overflow
+  /// For integer `E` the inner-product accumulation is not overflow-checked: it
+  /// panics in debug / wraps in release once a product or partial sum leaves
+  /// `E`'s range.
   #[ inline ]
   fn mul( self, rhs : Mat< COLS, COLS2, E, Descriptor > ) -> Self::Output
   {
@@ -105,6 +118,10 @@ where
 {
   type Output = Mat< ROWS, COLS2, E, Descriptor >;
 
+  /// # Overflow
+  /// For integer `E` the inner-product accumulation is not overflow-checked: it
+  /// panics in debug / wraps in release once a product or partial sum leaves
+  /// `E`'s range.
   #[ inline ]
   fn mul( self, rhs : &Mat< COLS, COLS2, E, Descriptor > ) -> Self::Output
   {
@@ -127,6 +144,10 @@ where
 {
   type Output = Vector< E, COLS >;
 
+  /// # Overflow
+  /// For integer `E` the inner-product accumulation is not overflow-checked: it
+  /// panics in debug / wraps in release once a product or partial sum leaves
+  /// `E`'s range.
   #[ inline ]
   fn mul( self, rhs : Vector< E, COLS > ) -> Self::Output
   {
@@ -145,6 +166,10 @@ where
 {
   type Output = Vector< E, COLS >;
 
+  /// # Overflow
+  /// For integer `E` the inner-product accumulation is not overflow-checked: it
+  /// panics in debug / wraps in release once a product or partial sum leaves
+  /// `E`'s range.
   #[ inline ]
   fn mul( self, rhs : &Vector< E, COLS > ) -> Self::Output
   {

--- a/module/math/ndarray_cg/src/vector/operator.rs
+++ b/module/math/ndarray_cg/src/vector/operator.rs
@@ -88,6 +88,10 @@ mod private
   {
     type Output = Vector< E, LEN >;
 
+    /// # Panics
+    /// For integer `E` this panics if any component of `rhs` is zero, in both
+    /// debug and release mode. For float `E`, remainder by zero yields `NAN`
+    /// instead.
     #[ inline ]
     fn rem( self, rhs : Self ) -> Self::Output
     {
@@ -118,6 +122,9 @@ mod private
   {
     type Output = Vector< E, LEN >;
 
+    /// # Panics
+    /// For integer `E` this panics if `scalar` is zero, in both debug and
+    /// release mode. For float `E`, remainder by zero yields `NAN` instead.
     #[ inline ]
     fn rem( self, scalar : E ) -> Self::Output
     {

--- a/module/math/ndarray_cg/tests/inc/integer_test/arithmetic_test.rs
+++ b/module/math/ndarray_cg/tests/inc/integer_test/arithmetic_test.rs
@@ -195,6 +195,69 @@ where
   assert_eq!( sum.raw_slice(), exp.raw_slice() );
 }
 
+fn mat_div_scalar_generic< E, D >()
+where
+  E : the_module::MatNum + From< u8 > + PartialEq + core::fmt::Debug,
+  D : the_module::mat::Descriptor + Copy,
+  the_module::Mat< 2, 2, E, D > :
+    the_module::IndexingMut +
+    the_module::RawSliceMut< Scalar = E > +
+    the_module::Indexable< Index = the_module::Ix2 > +
+    the_module::ScalarMut< Scalar = E, Index = the_module::Ix2 >,
+{
+  use the_module::Mat;
+  let a = Mat::< 2, 2, E, D >::default().set_raw
+  ([
+    E::from( 4 ),  E::from( 8 ),
+    E::from( 12 ), E::from( 16 ),
+  ]);
+  let exp = Mat::< 2, 2, E, D >::default().set_raw
+  ([
+    E::from( 1 ), E::from( 2 ),
+    E::from( 3 ), E::from( 4 ),
+  ]);
+
+  // owned / scalar
+  assert_eq!( ( a / E::from( 4 ) ).raw_slice(), exp.raw_slice() );
+
+  // /= scalar
+  let mut b = a;
+  b /= E::from( 4 );
+  assert_eq!( b.raw_slice(), exp.raw_slice() );
+}
+
+fn mat_div_scalar_signed_generic< E, D >()
+where
+  E : the_module::MatNum + ::num_traits::Signed + From< u8 > + PartialEq + core::fmt::Debug,
+  D : the_module::mat::Descriptor + Copy,
+  the_module::Mat< 2, 2, E, D > :
+    the_module::IndexingMut +
+    the_module::RawSliceMut< Scalar = E > +
+    the_module::Indexable< Index = the_module::Ix2 > +
+    the_module::ScalarMut< Scalar = E, Index = the_module::Ix2 >,
+{
+  use the_module::Mat;
+  // Integer division truncates toward zero: -7 / 4 == -1, not -2.
+  let a = Mat::< 2, 2, E, D >::default().set_raw
+  ([
+    -E::from( 4 ), -E::from( 7 ),
+    -E::from( 12 ), -E::from( 9 ),
+  ]);
+  let exp = Mat::< 2, 2, E, D >::default().set_raw
+  ([
+    -E::from( 1 ), -E::from( 1 ),
+    -E::from( 3 ), -E::from( 2 ),
+  ]);
+
+  // owned / scalar
+  assert_eq!( ( a / E::from( 4 ) ).raw_slice(), exp.raw_slice() );
+
+  // /= scalar
+  let mut b = a;
+  b /= E::from( 4 );
+  assert_eq!( b.raw_slice(), exp.raw_slice() );
+}
+
 fn mat_mat_mul_generic< E, D >()
 where
   E : the_module::MatNum + From< u8 > + PartialEq + core::fmt::Debug,
@@ -306,6 +369,18 @@ macro_rules! integer_arithmetic_tests
         }
 
         #[ test ]
+        fn mat_div_scalar_row_major()
+        {
+          mat_div_scalar_generic::< $ty, the_module::mat::DescriptorOrderRowMajor >();
+        }
+
+        #[ test ]
+        fn mat_div_scalar_column_major()
+        {
+          mat_div_scalar_generic::< $ty, the_module::mat::DescriptorOrderColumnMajor >();
+        }
+
+        #[ test ]
         fn mat_mat_mul_row_major()
         {
           mat_mat_mul_generic::< $ty, the_module::mat::DescriptorOrderRowMajor >();
@@ -361,3 +436,49 @@ fn vector_rem_signed_i64() { vector_rem_signed_generic::< i64 >(); }
 fn vector_div_signed_i32() { vector_div_signed_generic::< i32 >(); }
 #[ test ]
 fn vector_div_signed_i64() { vector_div_signed_generic::< i64 >(); }
+
+// Mat / scalar with negative dividends — truncates toward zero, signed only.
+
+#[ test ]
+fn mat_div_scalar_signed_i32()
+{
+  mat_div_scalar_signed_generic::< i32, the_module::mat::DescriptorOrderRowMajor >();
+  mat_div_scalar_signed_generic::< i32, the_module::mat::DescriptorOrderColumnMajor >();
+}
+
+#[ test ]
+fn mat_div_scalar_signed_i64()
+{
+  mat_div_scalar_signed_generic::< i64, the_module::mat::DescriptorOrderRowMajor >();
+  mat_div_scalar_signed_generic::< i64, the_module::mat::DescriptorOrderColumnMajor >();
+}
+
+// Zero-divisor panic tests — verify that the documented panic fires at runtime.
+
+#[ test ]
+#[ should_panic ]
+fn vector_div_zero_vector_panics()
+{
+  use the_module::Vector;
+  let a = Vector::< i32, 3 >::from_array( [ 1, 2, 3 ] );
+  let zero = Vector::< i32, 3 >::from_array( [ 1, 0, 1 ] );
+  let _ = a / zero;
+}
+
+#[ test ]
+#[ should_panic ]
+fn vector_div_zero_scalar_panics()
+{
+  use the_module::Vector;
+  let a = Vector::< i32, 3 >::from_array( [ 1, 2, 3 ] );
+  let _ = a / 0_i32;
+}
+
+#[ test ]
+#[ should_panic ]
+fn vector_rem_zero_scalar_panics()
+{
+  use the_module::Vector;
+  let a = Vector::< i32, 3 >::from_array( [ 1, 2, 3 ] );
+  let _ = a % 0_i32;
+}

--- a/module/math/ndarray_cg/tests/inc/integer_test/arithmetic_test.rs
+++ b/module/math/ndarray_cg/tests/inc/integer_test/arithmetic_test.rs
@@ -482,3 +482,13 @@ fn vector_rem_zero_scalar_panics()
   let a = Vector::< i32, 3 >::from_array( [ 1, 2, 3 ] );
   let _ = a % 0_i32;
 }
+
+#[ test ]
+#[ should_panic ]
+fn vector_rem_zero_component_panics()
+{
+  use the_module::Vector;
+  let a = Vector::< i32, 3 >::from_array( [ 1, 2, 3 ] );
+  let zero = Vector::< i32, 3 >::from_array( [ 3, 0, 1 ] );
+  let _ = a % zero;
+}

--- a/module/math/ndarray_cg/tests/inc/integer_test/arithmetic_test.rs
+++ b/module/math/ndarray_cg/tests/inc/integer_test/arithmetic_test.rs
@@ -457,7 +457,7 @@ fn mat_div_scalar_signed_i64()
 
 #[ test ]
 #[ should_panic ]
-fn vector_div_zero_vector_panics()
+fn vector_div_zero_component_panics()
 {
   use the_module::Vector;
   let a = Vector::< i32, 3 >::from_array( [ 1, 2, 3 ] );


### PR DESCRIPTION
## Summary

Follow-up fixes addressing review findings on `ndarray_cg` and `mdmath_core` math ops.

### Bug fix

- **Removed stray `println!`** from the inner loop of `d2/arithmetics/mul.rs` — every `Mat * Mat` or `Mat * Vector` call was emitting `(row, col)` pairs to stdout for every output element (16 lines per 4×4 multiply).

### Tests

- **`mat_div_scalar_generic`** — covers `Mat<2,2,E,D> / scalar` (owned and `DivAssign`) for `i32`, `i64`, `u32`, `u64` in both row- and column-major layouts (8 tests).
- **`mat_div_scalar_signed_generic`** — verifies Rust's truncation-toward-zero semantics for negative dividends (`-7 / 4 == -1`, not `-2`) for `i32` and `i64`.
- **`vector_div_zero_vector_panics`**, **`vector_div_zero_scalar_panics`**, **`vector_rem_zero_scalar_panics`** — `#[should_panic]` tests confirming that the documented integer zero-divisor panics actually fire at runtime.

### Documentation

- **`d2/arithmetics/add.rs`** — added `# Overflow` to the `add()` free-function and both `Add` impl blocks (`Mat + Mat`, `&Mat + &Mat`), matching the convention in `vector/operator/add.rs`.
- **`d2/arithmetics/mul.rs`** — added `# Overflow` to the `mul()` and `mul_mat_vec()` free-functions and all four `Mul` impl blocks (mat×mat owned, mat×mat ref, mat×vec owned, mat×vec ref).
- **`mdmath_core/vector/arithmetics.rs`** — added `# Overflow` to `cross_mut` and `cross`, noting that both the per-component multiplications and subtractions are unchecked.
- **`vector/operator.rs`** — added `# Panics` to the two reference-form `Rem` impls (`&Vector % &Vector` and `&Vector % scalar`), which were the only `Rem` impls in the file without this note.
