### PR TITLE
APPROVED : file loader: error propagation, blob/data URL support, inline buffer fix

### DIFF
--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -421,8 +421,14 @@ mod private
 
     // let gltf_slice= gl::file::load( &format!( "{}/scene.gltf", gltf_path ) )
     // .await.expect( "Failed to load gltf file" );
-    let gltf_slice = gl::file::load( gltf_path ).await.expect( "Failed to load gltf file" );
-    let mut gltf_file = gltf::Gltf::from_slice( &gltf_slice ).unwrap();
+    // Propagate fetch / parse failures as errors instead of panicking: an
+    // `.unwrap()` here aborts the whole wasm module (e.g. when a dev server
+    // returns an HTML 404 page, or the bytes are not a valid glTF/GLB), leaving
+    // it unusable for every subsequent call.
+    let gltf_slice = gl::file::load( gltf_path ).await
+    .map_err( | _ | gl::WebglError::Other( "Failed to load gltf file" ) )?;
+    let mut gltf_file = gltf::Gltf::from_slice( &gltf_slice )
+    .map_err( | _ | gl::WebglError::Other( "Failed to parse gltf file" ) )?;
 
     let mut buffers : Vec< gl::js_sys::Uint8Array > = Vec::new();
 
@@ -442,7 +448,7 @@ mod private
         {
           let path = format!( "{}/{}", folder_path, uri );
           let buffer = gl::file::load( &path ).await
-          .expect( "Failed to load a buffer" );
+          .map_err( | _ | gl::WebglError::Other( "Failed to load a buffer" ) )?;
 
           gl::debug!
           (

--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -436,6 +436,75 @@ mod private
     }
   }
 
+  #[ cfg( test ) ]
+  mod tests
+  {
+    use super::resolve_asset_uri;
+
+    #[ test ]
+    fn joins_relative_uri_with_folder()
+    {
+      assert_eq!
+      (
+        resolve_asset_uri( "models", "scene/buffer.bin" ),
+        "models/scene/buffer.bin"
+      );
+    }
+
+    #[ test ]
+    fn passes_blob_uri_through()
+    {
+      assert_eq!
+      (
+        resolve_asset_uri( "models", "blob:https://app.example.com/uuid-1234" ),
+        "blob:https://app.example.com/uuid-1234"
+      );
+    }
+
+    #[ test ]
+    fn passes_data_uri_through()
+    {
+      assert_eq!
+      (
+        resolve_asset_uri( "models", "data:application/octet-stream;base64,Z2xURg==" ),
+        "data:application/octet-stream;base64,Z2xURg=="
+      );
+    }
+
+    #[ test ]
+    fn passes_absolute_url_through()
+    {
+      assert_eq!
+      (
+        resolve_asset_uri( "models", "https://cdn.example.com/textures/t.png" ),
+        "https://cdn.example.com/textures/t.png"
+      );
+    }
+
+    #[ test ]
+    fn passes_origin_absolute_path_through()
+    {
+      assert_eq!
+      (
+        resolve_asset_uri( "models", "/textures/t.png" ),
+        "/textures/t.png"
+      );
+    }
+
+    #[ test ]
+    fn empty_folder_yields_origin_absolute_uri()
+    {
+      // Documents the benign empty-folder behavior: origin-absolute and
+      // origin-relative forms collapse to the same URL once `resolve_url`
+      // joins them against the window origin.
+      assert_eq!
+      (
+        resolve_asset_uri( "", "buffer.bin" ),
+        "/buffer.bin"
+      );
+    }
+  }
+
   /// Asynchronously loads a glTF (GL Transmission Format) file and its associated resources.
   pub async fn load
   (

--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -577,9 +577,28 @@ mod private
         }
       );
 
+      // Without an onerror handler a 404 or malformed image URI fails silently:
+      // the 1x1 white placeholder stays bound, nothing is logged, and load()
+      // still returns Ok. Mirror the error logging added for buffer URI loads so
+      // image failures are diagnosable instead of rendering as blank textures.
+      let on_error : Closure< dyn Fn() > = Closure::new
+      (
+        {
+          let img = img_element.clone();
+          let src = src.clone();
+          move ||
+          {
+            gl::browser::error!( "Failed to load gltf image '{src}'" );
+            img.remove();
+          }
+        }
+      );
+
       img_element.set_onload( Some( load_texture.as_ref().unchecked_ref() ) );
+      img_element.set_onerror( Some( on_error.as_ref().unchecked_ref() ) );
       img_element.set_src( &src );
       load_texture.forget();
+      on_error.forget();
     };
 
     // If a source of an image is Uri - load the file

--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -405,6 +405,32 @@ mod private
     )
   }
 
+  /// Resolves a glTF asset `uri` (buffer or image) against the model's `folder_path`.
+  ///
+  /// URIs that already carry their own location are returned unchanged, because
+  /// prefixing `folder_path` would corrupt them:
+  /// * absolute / protocol-relative URLs (`http://`, `https://`, `//`),
+  /// * self-contained URIs (`blob:`, `data:`),
+  /// * origin-absolute paths (leading `/`).
+  ///
+  /// Everything else is treated as folder-relative and joined with a single `/`.
+  fn resolve_asset_uri( folder_path : &str, uri : &str ) -> String
+  {
+    if uri.starts_with( "http://" )
+    || uri.starts_with( "https://" )
+    || uri.starts_with( "//" )
+    || uri.starts_with( "blob:" )
+    || uri.starts_with( "data:" )
+    || uri.starts_with( '/' )
+    {
+      uri.to_string()
+    }
+    else
+    {
+      format!( "{}/{}", folder_path, uri )
+    }
+  }
+
   /// Asynchronously loads a glTF (GL Transmission Format) file and its associated resources.
   pub async fn load
   (
@@ -446,21 +472,7 @@ mod private
       {
         gltf::buffer::Source::Uri( uri ) =>
         {
-          // Absolute URLs, data: and blob: URIs, and origin-absolute paths carry their
-          // own location — prepending folder_path would destroy the scheme or leading slash.
-          let path = if uri.starts_with( "http://" )
-          || uri.starts_with( "https://" )
-          || uri.starts_with( "//" )
-          || uri.starts_with( "blob:" )
-          || uri.starts_with( "data:" )
-          || uri.starts_with( '/' )
-          {
-            uri.to_string()
-          }
-          else
-          {
-            format!( "{}/{}", folder_path, uri )
-          };
+          let path = resolve_asset_uri( folder_path, uri );
           let buffer = gl::file::load( &path ).await
           .map_err( | _ | gl::WebglError::Other( "Failed to load a buffer" ) )?;
 
@@ -559,7 +571,7 @@ mod private
       {
         gltf::image::Source::Uri { uri, mime_type: _ } =>
         {
-          upload_texture( format!( "{}/{}", folder_path, uri ).into() );
+          upload_texture( resolve_asset_uri( folder_path, uri ).into() );
         },
         gltf::image::Source::View { view, mime_type } =>
         {

--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -416,12 +416,10 @@ mod private
   /// Everything else is treated as folder-relative and joined with a single `/`.
   fn resolve_asset_uri( folder_path : &str, uri : &str ) -> String
   {
-    if uri.starts_with( "http://" )
-    || uri.starts_with( "https://" )
-    || uri.starts_with( "//" )
-    || uri.starts_with( "blob:" )
-    || uri.starts_with( "data:" )
-    || uri.starts_with( '/' )
+    // `gl::file::load` already resolves self-contained URLs and origin-absolute
+    // paths against the window origin; only genuinely folder-relative URIs need
+    // the model's folder prefix folded in.
+    if gl::file::is_self_contained_url( uri ) || uri.starts_with( '/' )
     {
       uri.to_string()
     }

--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -449,10 +449,22 @@ mod private
     // `.unwrap()` here aborts the whole wasm module (e.g. when a dev server
     // returns an HTML 404 page, or the bytes are not a valid glTF/GLB), leaving
     // it unusable for every subsequent call.
+    // `WebglError::Other` only carries a `&'static str`, so the underlying
+    // `JsValue` / `gltf::Error` (file path, HTTP status, JSON parse location)
+    // would otherwise be lost. Log it to the console before mapping so a failed
+    // load is diagnosable in production.
     let gltf_slice = gl::file::load( gltf_path ).await
-    .map_err( | _ | gl::WebglError::Other( "Failed to load gltf file" ) )?;
+    .map_err( | e |
+    {
+      gl::browser::error!( "Failed to load gltf file '{gltf_path}': {e:?}" );
+      gl::WebglError::Other( "Failed to load gltf file" )
+    } )?;
     let mut gltf_file = gltf::Gltf::from_slice( &gltf_slice )
-    .map_err( | _ | gl::WebglError::Other( "Failed to parse gltf file" ) )?;
+    .map_err( | e |
+    {
+      gl::browser::error!( "Failed to parse gltf file '{gltf_path}': {e}" );
+      gl::WebglError::Other( "Failed to parse gltf file" )
+    } )?;
 
     let mut buffers : Vec< gl::js_sys::Uint8Array > = Vec::new();
 
@@ -472,7 +484,11 @@ mod private
         {
           let path = resolve_asset_uri( folder_path, uri );
           let buffer = gl::file::load( &path ).await
-          .map_err( | _ | gl::WebglError::Other( "Failed to load a buffer" ) )?;
+          .map_err( | e |
+          {
+            gl::browser::error!( "Failed to load gltf buffer '{path}': {e:?}" );
+            gl::WebglError::Other( "Failed to load a buffer" )
+          } )?;
 
           gl::debug!
           (

--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -564,7 +564,13 @@ mod private
             gl.generate_mipmap( gl::TEXTURE_2D );
             gl.tex_parameteri( gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR_MIPMAP_LINEAR as i32 );
 
-            gl::web_sys::Url::revoke_object_url( &src ).unwrap();
+            // revoke_object_url is specified only for blob: URLs; for data: URIs or
+            // plain file paths it is a no-op, and unwrapping its result is a latent
+            // panic hazard in stricter runtimes. Only revoke the urls we created.
+            if src.starts_with( "blob:" )
+            {
+              gl::web_sys::Url::revoke_object_url( &src ).unwrap();
+            }
 
             img.remove();
           }

--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -414,6 +414,13 @@ mod private
   /// * origin-absolute paths (leading `/`).
   ///
   /// Everything else is treated as folder-relative and joined with a single `/`.
+  ///
+  /// When `folder_path` is empty (the glTF was loaded from a bare filename, so it
+  /// sits at the origin root) a folder-relative `uri` resolves to `"/{uri}"`. This
+  /// is intentional and harmless: `resolve_url` joins both `"/buffer.bin"` and
+  /// `"buffer.bin"` against the origin to the same `"{origin}/buffer.bin"`. A glTF
+  /// served from a subdirectory must be loaded with that directory in `gltf_path`
+  /// (e.g. `"assets/scene.gltf"`), otherwise the glTF fetch itself fails first.
   fn resolve_asset_uri( folder_path : &str, uri : &str ) -> String
   {
     // `gl::file::load` already resolves self-contained URLs and origin-absolute

--- a/module/helper/renderer/src/webgl/loaders/gltf.rs
+++ b/module/helper/renderer/src/webgl/loaders/gltf.rs
@@ -446,7 +446,21 @@ mod private
       {
         gltf::buffer::Source::Uri( uri ) =>
         {
-          let path = format!( "{}/{}", folder_path, uri );
+          // Absolute URLs, data: and blob: URIs, and origin-absolute paths carry their
+          // own location — prepending folder_path would destroy the scheme or leading slash.
+          let path = if uri.starts_with( "http://" )
+          || uri.starts_with( "https://" )
+          || uri.starts_with( "//" )
+          || uri.starts_with( "blob:" )
+          || uri.starts_with( "data:" )
+          || uri.starts_with( '/' )
+          {
+            uri.to_string()
+          }
+          else
+          {
+            format!( "{}/{}", folder_path, uri )
+          };
           let buffer = gl::file::load( &path ).await
           .map_err( | _ | gl::WebglError::Other( "Failed to load a buffer" ) )?;
 

--- a/module/min/mingl/src/web/file.rs
+++ b/module/min/mingl/src/web/file.rs
@@ -46,6 +46,25 @@ mod private
     || url.starts_with( "data:" )
   }
 
+  /// Validates a `data:` URL and returns its base64-encoded payload (the text
+  /// after the comma), without decoding it.
+  ///
+  /// `url` is expected to begin with the `data:` scheme — `load` only calls this
+  /// after checking that prefix. Returns `Err` if the URL is malformed (no comma
+  /// separating the header from the payload) or if the payload is not declared as
+  /// base64 (`;base64` is the only supported encoding). The actual base64 decode
+  /// is left to the caller, because it relies on the browser's `window.atob`.
+  fn data_url_base64_payload( url : &str ) -> Result< &str, &'static str >
+  {
+    let comma_pos = url.find( ',' ).ok_or( "Malformed data URL: missing comma" )?;
+    let header = &url[ "data:".len()..comma_pos ];
+    if !header.ends_with( ";base64" )
+    {
+      return Err( "Only base64-encoded data URLs are supported" );
+    }
+    Ok( &url[ comma_pos + 1.. ] )
+  }
+
   // qqq : implement typed errors
   /// Asynchronously fetches a file over HTTP using the browser's `fetch` API,
   /// or decodes a `data:` URL inline without a network round-trip.
@@ -93,14 +112,7 @@ mod private
     // `fetch()` rejects `cors` mode for `data:` URLs — decode them directly instead.
     if url.starts_with( "data:" )
     {
-      let comma_pos = url.find( ',' )
-      .ok_or_else( || JsValue::from_str( "Malformed data URL: missing comma" ) )?;
-      let header = &url[ 5..comma_pos ]; // skip leading "data:"
-      let payload = &url[ comma_pos + 1.. ];
-      if !header.ends_with( ";base64" )
-      {
-        return Err( JsValue::from_str( "Only base64-encoded data URLs are supported" ) );
-      }
+      let payload = data_url_base64_payload( &url ).map_err( JsValue::from_str )?;
       let decoded = window.atob( payload )?;
       return Ok( decoded.chars().map( | c | c as u8 ).collect() );
     }
@@ -126,7 +138,7 @@ mod private
   #[ cfg( test ) ]
   mod tests
   {
-    use super::resolve_url;
+    use super::{ resolve_url, data_url_base64_payload };
 
     #[ test ]
     fn passes_https_url_through()
@@ -215,6 +227,48 @@ mod private
       (
         resolve_url( "https://app.example.com", "" ),
         "https://app.example.com/"
+      );
+    }
+
+    #[ test ]
+    fn data_url_returns_base64_payload()
+    {
+      assert_eq!
+      (
+        data_url_base64_payload( "data:application/octet-stream;base64,Z2xURg==" ),
+        Ok( "Z2xURg==" )
+      );
+    }
+
+    #[ test ]
+    fn data_url_with_empty_payload_is_ok()
+    {
+      // A `;base64` header with nothing after the comma is a well-formed,
+      // zero-length payload — `atob("")` returns the empty string.
+      assert_eq!
+      (
+        data_url_base64_payload( "data:application/octet-stream;base64," ),
+        Ok( "" )
+      );
+    }
+
+    #[ test ]
+    fn data_url_without_comma_is_err()
+    {
+      assert_eq!
+      (
+        data_url_base64_payload( "data:application/octet-stream;base64" ),
+        Err( "Malformed data URL: missing comma" )
+      );
+    }
+
+    #[ test ]
+    fn data_url_without_base64_marker_is_err()
+    {
+      assert_eq!
+      (
+        data_url_base64_payload( "data:text/plain,Hello" ),
+        Err( "Only base64-encoded data URLs are supported" )
       );
     }
   }

--- a/module/min/mingl/src/web/file.rs
+++ b/module/min/mingl/src/web/file.rs
@@ -56,16 +56,15 @@ mod private
   /// or a `JsValue` containing a JavaScript error on failure.
   ///
   /// # Errors
-  /// Returns the `JsValue` that the underlying `fetch` or `Response::array_buffer`
-  /// promise rejected with — typically a `TypeError` for network / CORS failures or
-  /// a `DOMException` for aborted reads. HTTP error status codes (4xx, 5xx) do
-  /// **not** produce an `Err` here; `fetch` resolves successfully and the caller
-  /// receives the response body as `Ok`.
+  /// Returns the `JsValue` that the underlying request construction, `fetch`, or
+  /// `Response::array_buffer` rejected with — typically a `TypeError` for network /
+  /// CORS failures or a `DOMException` for aborted reads. HTTP error status codes
+  /// (4xx, 5xx) do **not** produce an `Err` here; `fetch` resolves successfully and
+  /// the caller receives the response body as `Ok`.
   ///
   /// # Panics
-  /// Panics if the browser `window` object is unavailable, if the constructed URL
-  /// is rejected by `Request::new_with_str_and_init`, or if the initial `fetch`
-  /// promise itself rejects (as opposed to resolving with an error response).
+  /// Panics only if the browser `window` object is unavailable (i.e. not running in
+  /// a browsing context).
   pub async fn load( file_name : &str ) -> Result< Vec< u8 >, JsValue >
   {
 
@@ -77,10 +76,13 @@ mod private
     let origin = window.location().origin().unwrap();
     let url = resolve_url( &origin, file_name );
 
-    let request = web_sys::Request::new_with_str_and_init( &url, &opts ).expect( "Invalid url" );
+    // Propagate request-construction and fetch failures as `Err` rather than
+    // panicking: a rejected fetch (network error, CORS block, rate limit) must
+    // not abort the whole wasm module — callers can recover from a returned error.
+    let request = web_sys::Request::new_with_str_and_init( &url, &opts )?;
 
-    let resp_value = JsFuture::from( window.fetch_with_request( &request ) ).await.expect( "Fetch request fail" );
-    let resp : web_sys::Response = resp_value.dyn_into().unwrap();
+    let resp_value = JsFuture::from( window.fetch_with_request( &request ) ).await?;
+    let resp : web_sys::Response = resp_value.dyn_into()?;
     let array_buffer_promise = resp.array_buffer()?;
     let array_buffer = JsFuture::from( array_buffer_promise ).await?;
 

--- a/module/min/mingl/src/web/file.rs
+++ b/module/min/mingl/src/web/file.rs
@@ -7,6 +7,9 @@ mod private
   /// Resolves `file_name` against `origin` according to `load`'s contract.
   ///
   /// * Absolute URLs (`http://`, `https://`, `//`) pass through unchanged.
+  /// * Self-contained URLs (`blob:`, `data:`) pass through unchanged — these carry
+  ///   their own payload and must reach `fetch` verbatim; prefixing the origin
+  ///   mangles them into an unresolvable same-origin path.
   /// * Origin-absolute paths (leading `/`) are appended to the origin as-is.
   /// * Anything else is treated as origin-relative and joined with a single `/`.
   fn resolve_url( origin : &str, file_name : &str ) -> String
@@ -14,6 +17,8 @@ mod private
     if file_name.starts_with( "http://" )
     || file_name.starts_with( "https://" )
     || file_name.starts_with( "//" )
+    || file_name.starts_with( "blob:" )
+    || file_name.starts_with( "data:" )
     {
       file_name.to_string()
     }
@@ -31,8 +36,9 @@ mod private
   /// Asynchronously fetches a file over HTTP using the browser's `fetch` API.
   ///
   /// The argument is used verbatim as a URL or path; no folder prefix is added.
-  /// Three forms are accepted:
+  /// These forms are accepted:
   /// * Absolute URL (`http://...`, `https://...`, or protocol-relative `//...`) — fetched as-is.
+  /// * Self-contained URL (`blob:...`, `data:...`) — fetched as-is.
   /// * Origin-absolute path (`/assets/foo.png`) — joined to the window origin.
   /// * Origin-relative path (`static/foo.png`, `foo.png`) — joined to the window origin with `/`.
   ///
@@ -117,6 +123,26 @@ mod private
       (
         resolve_url( "https://app.example.com", "//cdn.example.com/foo.glb" ),
         "//cdn.example.com/foo.glb"
+      );
+    }
+
+    #[ test ]
+    fn passes_blob_url_through()
+    {
+      assert_eq!
+      (
+        resolve_url( "https://app.example.com", "blob:https://app.example.com/uuid-1234" ),
+        "blob:https://app.example.com/uuid-1234"
+      );
+    }
+
+    #[ test ]
+    fn passes_data_url_through()
+    {
+      assert_eq!
+      (
+        resolve_url( "https://app.example.com", "data:application/octet-stream;base64,Z2xURg==" ),
+        "data:application/octet-stream;base64,Z2xURg=="
       );
     }
 

--- a/module/min/mingl/src/web/file.rs
+++ b/module/min/mingl/src/web/file.rs
@@ -33,12 +33,16 @@ mod private
   }
 
   // qqq : implement typed errors
-  /// Asynchronously fetches a file over HTTP using the browser's `fetch` API.
+  /// Asynchronously fetches a file over HTTP using the browser's `fetch` API,
+  /// or decodes a `data:` URL inline without a network round-trip.
   ///
   /// The argument is used verbatim as a URL or path; no folder prefix is added.
   /// These forms are accepted:
   /// * Absolute URL (`http://...`, `https://...`, or protocol-relative `//...`) — fetched as-is.
-  /// * Self-contained URL (`blob:...`, `data:...`) — fetched as-is.
+  /// * `blob:` URL — fetched as-is using `fetch`.
+  /// * `data:` URL (e.g. `data:application/octet-stream;base64,...`) — decoded directly
+  ///   without a network request. Only base64-encoded payloads are supported; non-base64
+  ///   data URLs return `Err`.
   /// * Origin-absolute path (`/assets/foo.png`) — joined to the window origin.
   /// * Origin-relative path (`static/foo.png`, `foo.png`) — joined to the window origin with `/`.
   ///
@@ -49,7 +53,7 @@ mod private
   /// An empty `file_name` resolves to `{origin}/` and is almost certainly a caller bug.
   ///
   /// # Arguments
-  /// * `file_name` - URL or origin-relative path of the file to fetch.
+  /// * `file_name` - URL, data URI, or origin-relative path of the file to load.
   ///
   /// # Returns
   /// A `Result` which is either a `Vec<u8>` containing the file's byte data on success,
@@ -61,20 +65,35 @@ mod private
   /// CORS failures or a `DOMException` for aborted reads. HTTP error status codes
   /// (4xx, 5xx) do **not** produce an `Err` here; `fetch` resolves successfully and
   /// the caller receives the response body as `Ok`.
+  /// For `data:` URLs, returns `Err` if the URL is malformed or does not use base64 encoding.
   ///
   /// # Panics
   /// Panics only if the browser `window` object is unavailable (i.e. not running in
   /// a browsing context).
   pub async fn load( file_name : &str ) -> Result< Vec< u8 >, JsValue >
   {
+    let window = web_sys::window().unwrap();
+    let origin = window.location().origin()?;
+    let url = resolve_url( &origin, file_name );
+
+    // `fetch()` rejects `cors` mode for `data:` URLs — decode them directly instead.
+    if url.starts_with( "data:" )
+    {
+      let comma_pos = url.find( ',' )
+      .ok_or_else( || JsValue::from_str( "Malformed data URL: missing comma" ) )?;
+      let header = &url[ 5..comma_pos ]; // skip leading "data:"
+      let payload = &url[ comma_pos + 1.. ];
+      if !header.ends_with( ";base64" )
+      {
+        return Err( JsValue::from_str( "Only base64-encoded data URLs are supported" ) );
+      }
+      let decoded = window.atob( payload )?;
+      return Ok( decoded.chars().map( | c | c as u8 ).collect() );
+    }
 
     let opts = web_sys::RequestInit::new();
     opts.set_method( "GET" );
     opts.set_mode( web_sys::RequestMode::Cors );
-
-    let window = web_sys::window().unwrap();
-    let origin = window.location().origin().unwrap();
-    let url = resolve_url( &origin, file_name );
 
     // Propagate request-construction and fetch failures as `Err` rather than
     // panicking: a rejected fetch (network error, CORS block, rate limit) must
@@ -87,10 +106,7 @@ mod private
     let array_buffer = JsFuture::from( array_buffer_promise ).await?;
 
     let uint8_array = js_sys::Uint8Array::new( &array_buffer );
-    let mut data = vec![ 0; uint8_array.length() as usize ];
-    uint8_array.copy_to( &mut data[ .. ] );
-
-    Ok( data )
+    Ok( uint8_array.to_vec() )
   }
 
   #[ cfg( test ) ]

--- a/module/min/mingl/src/web/file.rs
+++ b/module/min/mingl/src/web/file.rs
@@ -28,15 +28,18 @@ mod private
     }
   }
 
-  /// Returns `true` for URLs that already carry their own location and must reach
-  /// the network layer verbatim: absolute (`http://`, `https://`), protocol-relative
-  /// (`//`), and self-contained (`blob:`, `data:`) URLs.
+  /// Returns `true` for URLs that already carry their own location and must never
+  /// be prefixed with an origin or a folder path — doing so mangles them into an
+  /// unresolvable same-origin path. Two subcategories qualify:
+  /// * absolute (`http://`, `https://`), protocol-relative (`//`), and `blob:` URLs,
+  ///   which reach `fetch` verbatim, and
+  /// * self-contained `data:` payloads, which `load` decodes inline (see its `data:`
+  ///   branch) and which never reach the network at all — `fetch` rejects `cors`
+  ///   mode for `data:` URIs.
   ///
-  /// Such URLs must never be prefixed with an origin or a folder path — doing so
-  /// mangles them into an unresolvable same-origin path. Note that origin-absolute
-  /// paths (a leading `/`) are deliberately *not* covered here: they carry no scheme
-  /// and the caller still has to join them to an origin or pass them through,
-  /// depending on context.
+  /// Note that origin-absolute paths (a leading `/`) are deliberately *not* covered
+  /// here: they carry no scheme and the caller still has to join them to an origin
+  /// or pass them through, depending on context.
   pub fn is_self_contained_url( url : &str ) -> bool
   {
     url.starts_with( "http://" )

--- a/module/min/mingl/src/web/file.rs
+++ b/module/min/mingl/src/web/file.rs
@@ -117,6 +117,12 @@ mod private
     {
       let payload = data_url_base64_payload( &url ).map_err( JsValue::from_str )?;
       let decoded = window.atob( payload )?;
+      // `atob` returns a DOMString whose code points are Latin-1 bytes
+      // (U+0000–U+00FF per Web IDL). Each `char` scalar therefore fits in a `u8`,
+      // so `c as u8` truncation is lossless and reconstructs the original binary
+      // payload. Do not "simplify" this to byte-length arithmetic over the string:
+      // wasm-bindgen transports the DOMString as UTF-8, where every U+0080–U+00FF
+      // code point is two bytes, so `.bytes()` would corrupt non-ASCII payloads.
       return Ok( decoded.chars().map( | c | c as u8 ).collect() );
     }
 

--- a/module/min/mingl/src/web/file.rs
+++ b/module/min/mingl/src/web/file.rs
@@ -14,11 +14,7 @@ mod private
   /// * Anything else is treated as origin-relative and joined with a single `/`.
   fn resolve_url( origin : &str, file_name : &str ) -> String
   {
-    if file_name.starts_with( "http://" )
-    || file_name.starts_with( "https://" )
-    || file_name.starts_with( "//" )
-    || file_name.starts_with( "blob:" )
-    || file_name.starts_with( "data:" )
+    if is_self_contained_url( file_name )
     {
       file_name.to_string()
     }
@@ -30,6 +26,24 @@ mod private
     {
       format!( "{}/{}", origin, file_name )
     }
+  }
+
+  /// Returns `true` for URLs that already carry their own location and must reach
+  /// the network layer verbatim: absolute (`http://`, `https://`), protocol-relative
+  /// (`//`), and self-contained (`blob:`, `data:`) URLs.
+  ///
+  /// Such URLs must never be prefixed with an origin or a folder path — doing so
+  /// mangles them into an unresolvable same-origin path. Note that origin-absolute
+  /// paths (a leading `/`) are deliberately *not* covered here: they carry no scheme
+  /// and the caller still has to join them to an origin or pass them through,
+  /// depending on context.
+  pub fn is_self_contained_url( url : &str ) -> bool
+  {
+    url.starts_with( "http://" )
+    || url.starts_with( "https://" )
+    || url.starts_with( "//" )
+    || url.starts_with( "blob:" )
+    || url.starts_with( "data:" )
   }
 
   // qqq : implement typed errors
@@ -211,5 +225,6 @@ crate::mod_interface!
 {
 
   own use load;
+  own use is_self_contained_url;
 
 }


### PR DESCRIPTION
## Problem

`file::load` and the glTF loader used `.expect()` / `.unwrap()` at every failure
point. In a WASM module, a panic aborts the entire module and leaves it permanently
broken — the user has to reload the page. Any transient error (network blip, typo in
a path, bad glTF file during development) triggered this abort.

Additionally, passing `blob:` or `data:` URLs to `load` was broken in two independent
ways that were not obvious from reading the code.

## Changes

### `mingl` — `web/file.rs`

**Error propagation** (`load`):

- `Request::new_with_str_and_init` — was `.expect("Invalid url")`, now `?`
- `fetch_with_request` — was `.expect("Fetch request fail")`, now `?`
- `resp_value.dyn_into::<Response>()` — was `.unwrap()`, now `?`
- `window.location().origin()` — was `.unwrap()`, now `?`; the `# Panics` doc
  previously listed this as a panic site but the updated doc omitted it — fixed.

**`blob:` and `data:` URL support** (`resolve_url`):

- Both schemes are now passed through unchanged, just like `http://`/`https://`/`//`.
  Without this, `blob:https://...` or `data:...` would have been treated as
  origin-relative paths and prefixed with the window origin, producing an
  unresolvable URL.
- Two new unit tests cover the passthrough behaviour.

**`data:` URL decoding** (`load`):

- Browsers reject `fetch()` with `RequestMode::Cors` when the URL is a `data:` URL
  (the Fetch spec disallows CORS mode for non-HTTP schemes; Chrome and Firefox both
  throw `TypeError: Failed to fetch`). Simply adding `data:` to the passthrough list
  in `resolve_url` was therefore not enough — the fetch would still fail.
- `data:` URLs are now short-circuited before the `RequestInit` is constructed:
  the base64 payload is decoded via `window.atob()` and returned directly. This
  avoids the network entirely, which is also faster.
- Only `;base64`-encoded data URLs are supported; non-base64 payloads return `Err`.

**Cleanup**:

- `vec![0; len]; uint8_array.copy_to(&mut data[..])` → `uint8_array.to_vec()`.
  The old form zero-initialised the buffer and then overwrote every byte; `to_vec`
  allocates uninitialised capacity and writes once.

### `renderer` — `webgl/loaders/gltf.rs`

**Error propagation** (glTF / buffer loading):

- Loading the root glTF file — was `.expect(...)` + `.unwrap()`, now
  `.map_err(|_| WebglError::Other(...))?` for both the fetch and the parse step.
- Loading each external buffer — was `.expect(...)`, now
  `.map_err(|_| WebglError::Other(...))?`.

**Inline buffer (`data:` URI) fix**:

- The glTF spec allows `buffer.uri` to be a `data:` URI (a base64-encoded inline
  buffer). The loader unconditionally did `format!("{}/{}", folder_path, uri)`,
  which prepended the folder path to the raw URI string — producing something like
  `"models/data:application/octet-stream;base64,..."`. This garbled string reached
  `resolve_url` as an origin-relative path and the fetch failed.
- The buffer path construction now checks the URI scheme first and only prepends
  `folder_path` for relative paths; absolute URLs, `blob:`, `data:`, and
  origin-absolute (`/`) URIs are used verbatim.

## Behaviour that did not change

- HTTP 4xx/5xx responses still resolve as `Ok` (the body of the error page is
  returned). This is intentional and documented: `fetch` resolves successfully for
  any HTTP response; callers that care about the status must inspect it themselves.
- `web_sys::window().unwrap()` still panics when called outside a browsing context
  (Worker, SSR). This is documented and intentional — the function is explicitly
  a browser-only API.
